### PR TITLE
ci: bump checkout to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -50,7 +50,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -69,7 +69,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -96,7 +96,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Buildx
@@ -175,7 +175,7 @@ jobs:
       security-events: write # Required for uploading SARIF results
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Generate Changelog
@@ -315,7 +315,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,18 +46,18 @@ jobs:
               core.setOutput('pr_number', '');
               return;
             }
-            
+
             // For issue_comment, check conditions
             const comment = context.payload.comment.body;
             const isPR = !!context.payload.issue.pull_request;
             const isCommand = comment.trim().startsWith('/run-e2e');
-            
+
             if (!isPR || !isCommand) {
               console.log(`Skipping: isPR=${isPR}, isCommand=${isCommand}`);
               core.setOutput('should_run', 'false');
               return;
             }
-            
+
             // Check if user has write access
             try {
               const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -77,14 +77,14 @@ jobs:
               core.setOutput('should_run', 'false');
               return;
             }
-            
+
             // Get PR ref
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            
+
             // Add rocket reaction (optional - don't fail if permissions insufficient)
             try {
               await github.rest.reactions.createForIssueComment({
@@ -97,7 +97,7 @@ jobs:
             } catch (e) {
               console.log(`Could not add reaction (permissions may be insufficient): ${e.message}`);
             }
-            
+
             console.log(`Triggered! PR ref: ${pr.data.head.ref}`);
             core.setOutput('should_run', 'true');
             core.setOutput('pr_ref', pr.data.head.ref);
@@ -127,7 +127,7 @@ jobs:
             });
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.check-trigger.outputs.pr_ref || github.ref }}
 

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -88,7 +88,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       new_release_version: ${{ steps.semantic_dry.outputs.new_release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -51,11 +51,11 @@ jobs:
     permissions:
       contents: write
       packages: write
-      id-token: write  # Required for cosign keyless signing
-      security-events: write  # Required for uploading SARIF results
+      id-token: write # Required for cosign keyless signing
+      security-events: write # Required for uploading SARIF results
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
 
@@ -130,21 +130,21 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      
+
       - name: Generate SBOM (SPDX)
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/uptime-robot-operator@${{ steps.build.outputs.digest }}
           format: 'spdx-json'
           output: 'sbom-spdx.json'
-      
+
       - name: Generate SBOM (CycloneDX)
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/uptime-robot-operator@${{ steps.build.outputs.digest }}
           format: 'cyclonedx'
           output: 'sbom-cyclonedx.json'
-      
+
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -152,17 +152,17 @@ jobs:
           path: |
             sbom-spdx.json
             sbom-cyclonedx.json
-      
+
       # Image Signing with Cosign
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.0
-      
+
       - name: Sign container images
         run: |
           IMAGE_DIGEST="ghcr.io/${{ github.repository_owner }}/uptime-robot-operator@${{ steps.build.outputs.digest }}"
           echo "Signing ${IMAGE_DIGEST}"
           cosign sign --yes "${IMAGE_DIGEST}"
-      
+
       - name: Attest SBOM to images
         run: |
           IMAGE_DIGEST="ghcr.io/${{ github.repository_owner }}/uptime-robot-operator@${{ steps.build.outputs.digest }}"
@@ -185,7 +185,7 @@ jobs:
       new_release_version: ${{ steps.semantic_publish.outputs.new_release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -235,7 +235,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: v${{ needs.release.outputs.new_release_version }}
 
@@ -268,7 +268,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: v${{ needs.release.outputs.new_release_version }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest major version of the `actions/checkout` action (`v6` instead of `v4`). This ensures that all CI/CD workflows benefit from the latest features, improvements, and security patches provided by the newer version.

**CI/CD Workflow Updates:**

* Updated all instances of `actions/checkout@v4` to `actions/checkout@v6` in the following workflow files:
  - `.github/workflows/build.yml` [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L34-R34) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L53-R53) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L72-R72) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L99-R99) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L178-R178) [[6]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L297-R297) [[7]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L318-R318)
  - `.github/workflows/e2e-pr.yml`
  - `.github/workflows/e2e.yml`
  - `.github/workflows/gitleaks.yaml`
  - `.github/workflows/helm.yml` [[1]](diffhunk://#diff-c6d51e33c2cb8931e4a3fc967207a870628eff8c3e77c4b458337d605db82922L25-R25) [[2]](diffhunk://#diff-c6d51e33c2cb8931e4a3fc967207a870628eff8c3e77c4b458337d605db82922L43-R43) [[3]](diffhunk://#diff-c6d51e33c2cb8931e4a3fc967207a870628eff8c3e77c4b458337d605db82922L91-R91)
  - `.github/workflows/release.yml` [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L27-R27) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L58-R58) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L188-R188) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L238-R238) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L271-R271)