### PR TITLE
fix(ci): make e2e deploy install cert-manager first

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Check trigger conditions
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // For workflow_dispatch, always run
@@ -115,7 +115,7 @@ jobs:
     steps:
       - name: Comment - E2E Started
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ needs.check-trigger.outputs.pr_ref || github.ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -163,7 +163,7 @@ jobs:
 
       - name: Deploy operator
         run: |
-          make deploy IMG=uptime-robot-operator:e2e
+          make deploy-with-cert-manager IMG=uptime-robot-operator:e2e
 
       - name: Wait for operator to be ready
         run: |
@@ -193,7 +193,7 @@ jobs:
 
       - name: Comment - E2E Passed
         if: success() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -206,7 +206,7 @@ jobs:
 
       - name: Comment - E2E Failed
         if: failure() && github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;


### PR DESCRIPTION
Use deploy-with-cert-manager in both e2e workflows so deploy no longer fails cert-manager-check on fresh Kind clusters.