### PR TITLE
fix(ci): align e2e workflow go version with go.mod

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24.13'
   KIND_VERSION: 'v0.25.0'
   KIND_CLUSTER_NAME: 'e2e-test'
 


### PR DESCRIPTION
Update e2e.yml GO_VERSION from 1.23 to 1.24.13 so controller-gen and make install succeed under the module's minimum Go requirement.