### PR TITLE
docs: add guide for Slack integration and monitor groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ EOF
 | [Getting Started](docs/getting-started.md) | Create your first monitor (tutorial) |
 | [Security](SECURITY.md) | Verify images and deployment best practices |
 | [Monitors](docs/monitors.md) | Configure monitor types and alerts |
+| [Slack Alerting](docs/slack-alerting.md) | Configure Slack integration and wire alerts to monitors |
 | [Metrics](docs/metrics.md) | Prometheus metrics and Grafana dashboards |
 | [Migration Guide](docs/migration-guide.md) | Adopt existing UptimeRobot resources |
 | [Maintenance Windows](docs/maintenance-windows.md) | Schedule planned downtime |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ EOF
 | [Getting Started](docs/getting-started.md) | Create your first monitor (tutorial) |
 | [Security](SECURITY.md) | Verify images and deployment best practices |
 | [Monitors](docs/monitors.md) | Configure monitor types and alerts |
+| [Monitor Groups](docs/monitor-groups.md) | Group monitors and manage membership declaratively |
 | [Slack Alerting](docs/slack-alerting.md) | Configure Slack integration and wire alerts to monitors |
 | [Metrics](docs/metrics.md) | Prometheus metrics and Grafana dashboards |
 | [Migration Guide](docs/migration-guide.md) | Adopt existing UptimeRobot resources |

--- a/docs/monitor-groups.md
+++ b/docs/monitor-groups.md
@@ -1,0 +1,102 @@
+# Configure Monitor Groups
+
+Create and manage UptimeRobot monitor groups using the `MonitorGroup` custom resource.
+
+## Prerequisites
+
+- You have installed the operator.
+- You have an `Account` resource that is `Ready`.
+- You have one or more `Monitor` resources in the same namespace.
+
+## How monitor groups work
+
+- `MonitorGroup` is a namespaced resource.
+- `spec.monitors` references `Monitor` resources by name in the same namespace.
+- The controller resolves each referenced monitor from `status.id`.
+- If a monitor is missing or not ready, the controller skips it until a later reconcile.
+
+## Create a monitor group from monitor references
+
+This example groups two monitors named `api-health` and `web-frontend`.
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: MonitorGroup
+metadata:
+  name: production-services
+  namespace: uptime-robot-system
+spec:
+  account:
+    name: default
+  friendlyName: production-services
+  prune: true
+  syncInterval: 24h
+  monitors:
+    - name: api-health
+    - name: web-frontend
+```
+
+Apply:
+
+```bash
+kubectl apply -f monitorgroup-production-services.yaml
+```
+
+Verify:
+
+```bash
+kubectl get monitorgroup production-services -n uptime-robot-system
+kubectl get monitorgroup production-services -n uptime-robot-system -o jsonpath='{.status.ready}{"\t"}{.status.id}{"\t"}{.status.monitorCount}{"\n"}'
+```
+
+## Pull monitors from existing group IDs
+
+Use `pullFromGroups` when you want this group to include monitors from existing UptimeRobot groups.
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: MonitorGroup
+metadata:
+  name: shared-services
+  namespace: uptime-robot-system
+spec:
+  account:
+    name: default
+  friendlyName: shared-services
+  prune: true
+  syncInterval: 24h
+  pullFromGroups:
+    - 12345
+    - 67890
+```
+
+Apply:
+
+```bash
+kubectl apply -f monitorgroup-shared-services.yaml
+```
+
+## Combine both approaches
+
+You can use both fields in one resource:
+
+- `monitors` for explicit monitor references from Kubernetes.
+- `pullFromGroups` for existing UptimeRobot group IDs.
+
+## Monitor-level `groupId` vs `MonitorGroup`
+
+You can also set `spec.monitor.groupId` on a `Monitor`.  
+Use one primary approach per use case to avoid confusion:
+
+- Use `MonitorGroup` when you want group membership managed centrally.
+- Use monitor-level `groupId` when group assignment is specific to each monitor resource.
+
+## Troubleshooting
+
+- Group is not ready:
+  Check `kubectl describe monitorgroup <name> -n <namespace>` for account/API errors.
+- `monitorCount` is lower than expected:
+  Verify referenced monitors exist, are ready, and have `status.id` populated.
+- Group not updated after monitor changes:
+  Confirm monitors are in the same namespace as the `MonitorGroup`.
+

--- a/docs/monitors.md
+++ b/docs/monitors.md
@@ -2,6 +2,10 @@
 
 Configure different monitor types, alert contacts, and monitoring behaviour.
 
+Related guides:
+- [Configure Monitor Groups](monitor-groups.md)
+- [Configure Slack Alerting for Monitors](slack-alerting.md)
+
 ## Monitor Types
 
 ### HTTPS

--- a/docs/monitors.md
+++ b/docs/monitors.md
@@ -154,6 +154,8 @@ spec:
 
 ## Alert Contacts
 
+For a complete Slack workflow (create `SlackIntegration`, create `Contact`, wire into `Monitor`), see [Configure Slack Alerting for Monitors](slack-alerting.md).
+
 ### Using Default Contact
 
 Monitors automatically use the default contact:

--- a/docs/slack-alerting.md
+++ b/docs/slack-alerting.md
@@ -1,0 +1,148 @@
+# Configure Slack Alerting for Monitors
+
+Set up Slack notifications in UptimeRobot and attach them to monitors managed by this operator.
+
+## Prerequisites
+
+- You have installed the operator.
+- You have an `Account` resource that is `Ready`.
+- You have a Slack incoming webhook URL for your target channel.
+
+## How Slack alerting works
+
+- `SlackIntegration` manages the Slack webhook integration in UptimeRobot.
+- `Monitor` resources do not reference `SlackIntegration` directly.
+- `Monitor` resources send alerts through `Contact` resources in `spec.contacts`.
+- Your `Contact` must point at a Slack alert contact that exists in your UptimeRobot account.
+
+Use this flow:
+
+1. Create a `SlackIntegration` resource.
+2. Ensure a Slack alert contact exists in UptimeRobot.
+3. Create a `Contact` resource that references that alert contact.
+4. Reference that `Contact` from your `Monitor.spec.contacts`.
+
+## Step 1: Create a SlackIntegration
+
+Store your webhook URL in a Secret:
+
+```bash
+kubectl create secret generic platform-alerts-webhook \
+  -n uptime-robot-system \
+  --from-literal=webhookURL='https://example.invalid/your-slack-webhook-url'
+```
+
+Create the `SlackIntegration`:
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: SlackIntegration
+metadata:
+  name: platform-alerts
+  namespace: uptime-robot-system
+spec:
+  account:
+    name: default
+  syncInterval: 24h
+  prune: true
+  integration:
+    friendlyName: platform-alerts
+    secretName: platform-alerts-webhook
+    webhookURLKey: webhookURL
+    enableNotificationsFor: UpAndDown
+    sslExpirationReminder: true
+```
+
+Apply:
+
+```bash
+kubectl apply -f slackintegration.yaml
+```
+
+Verify:
+
+```bash
+kubectl get slackintegration platform-alerts -n uptime-robot-system
+kubectl get slackintegration platform-alerts -n uptime-robot-system -o jsonpath='{.status.ready}{"\t"}{.status.id}{"\n"}'
+```
+
+## Step 2: Find the Slack alert contact ID
+
+List contacts visible to your account:
+
+```bash
+kubectl get account default -o jsonpath='{range .status.alertContacts[*]}{.id}{"\t"}{.friendlyName}{"\t"}{.type}{"\n"}{end}'
+```
+
+Pick the Slack contact ID (or friendly name) you want monitors to use.
+
+## Step 3: Create a Contact resource for Slack
+
+Reference by ID:
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Contact
+metadata:
+  name: platform-alerts-slack
+spec:
+  contact:
+    id: "1234567"
+```
+
+Or reference by friendly name:
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Contact
+metadata:
+  name: platform-alerts-slack
+spec:
+  contact:
+    name: "platform-alerts"
+```
+
+Apply and verify:
+
+```bash
+kubectl apply -f contact-slack.yaml
+kubectl get contact platform-alerts-slack -o jsonpath='{.status.ready}{"\t"}{.status.id}{"\n"}'
+```
+
+## Step 4: Wire the Contact into a Monitor
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Monitor
+metadata:
+  name: api-health
+spec:
+  account:
+    name: default
+  contacts:
+    - name: platform-alerts-slack
+      threshold: 1m
+      recurrence: 15m
+  monitor:
+    name: API Health
+    url: https://api.example.com/health
+    type: HTTPS
+    interval: 1m
+    method: GET
+```
+
+Apply and verify:
+
+```bash
+kubectl apply -f monitor-api-health.yaml
+kubectl get monitor api-health -o jsonpath='{.status.ready}{"\t"}{.status.id}{"\n"}'
+```
+
+## Troubleshooting
+
+- `SlackIntegration` not ready:
+  Check `kubectl describe slackintegration <name> -n <namespace>` for webhook/account errors.
+- `Contact` not ready:
+  Confirm the referenced contact exists in account status and ID/name matches exactly.
+- `Monitor` has no Slack notifications:
+  Confirm the monitor includes the Slack `Contact` in `spec.contacts`.


### PR DESCRIPTION
This pull request adds comprehensive documentation for two major features: Monitor Groups and Slack Alerting integration, and updates references throughout the docs to improve discoverability and user guidance.

**New feature documentation:**

* Monitor Groups:
  - Added a new guide (`docs/monitor-groups.md`) explaining how to group monitors using the `MonitorGroup` resource, reference monitors declaratively, and troubleshoot group issues.
  - Linked the Monitor Groups documentation from the main README and the Monitors guide for better navigation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R97) [[2]](diffhunk://#diff-176df6e1dc47c3c4b17d90ac6f3e0d192ffe4fdd4ab6d6eb4963e0ecafa5702bR5-R8)

* Slack Alerting:
  - Added a new guide (`docs/slack-alerting.md`) detailing the setup of Slack alerting via `SlackIntegration`, how to wire alert contacts into monitors, and troubleshooting steps.
  - Added cross-references in the Monitors guide to the new Slack Alerting documentation, including a direct link in the Alert Contacts section. [[1]](diffhunk://#diff-176df6e1dc47c3c4b17d90ac6f3e0d192ffe4fdd4ab6d6eb4963e0ecafa5702bR5-R8) [[2]](diffhunk://#diff-176df6e1dc47c3c4b17d90ac6f3e0d192ffe4fdd4ab6d6eb4963e0ecafa5702bR161-R162)

These changes make it easier for users to configure advanced features and understand how to integrate alerting and monitor grouping in their UptimeRobot operator setup.