### PR TITLE
fix: send monitor contact threshold in minutes, not seconds

### DIFF
--- a/internal/uptimerobot/client.go
+++ b/internal/uptimerobot/client.go
@@ -614,8 +614,11 @@ func contactsToV3Format(contacts uptimerobotv1.MonitorContacts) []AssignedAlertC
 		if c.ID == "" {
 			continue
 		}
-		// Calculate threshold in seconds (per-contact wait time before alerting)
-		threshold := int(c.Threshold.Seconds())
+		// Per-contact wait time before alerting. UptimeRobot v3 expects this
+		// in MINUTES (same as recurrence). Previously converted to seconds,
+		// which the API silently treated as minutes — turning a 1m spec
+		// default into a 60-minute (1 hour) effective delay in the UI.
+		threshold := int(c.Threshold.Round(time.Minute).Minutes())
 		if threshold < 0 {
 			threshold = 0
 		}

--- a/internal/uptimerobot/client_contacts_v3_test.go
+++ b/internal/uptimerobot/client_contacts_v3_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uptimerobot
+
+import (
+	"testing"
+	"time"
+
+	uptimerobotv1 "github.com/joelp172/uptime-robot-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestContactsToV3Format_ThresholdAndRecurrenceInMinutes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		threshold      time.Duration
+		recurrence     time.Duration
+		wantThreshold  int
+		wantRecurrence int
+	}{
+		{
+			name:           "1m default threshold sends as 1 minute (not 60)",
+			threshold:      1 * time.Minute,
+			recurrence:     0,
+			wantThreshold:  1,
+			wantRecurrence: 0,
+		},
+		{
+			name:           "5m threshold, 15m recurrence",
+			threshold:      5 * time.Minute,
+			recurrence:     15 * time.Minute,
+			wantThreshold:  5,
+			wantRecurrence: 15,
+		},
+		{
+			name:           "zero threshold",
+			threshold:      0,
+			recurrence:     0,
+			wantThreshold:  0,
+			wantRecurrence: 0,
+		},
+		{
+			name:           "sub-minute threshold rounds to nearest minute (UptimeRobot granularity)",
+			threshold:      29 * time.Second, // <30s → rounds to 0
+			recurrence:     0,
+			wantThreshold:  0,
+			wantRecurrence: 0,
+		},
+		{
+			name:           "sub-minute threshold at 31s rounds up to 1 minute",
+			threshold:      31 * time.Second,
+			recurrence:     0,
+			wantThreshold:  1,
+			wantRecurrence: 0,
+		},
+		{
+			name:           "large threshold preserved",
+			threshold:      60 * time.Minute,
+			recurrence:     30 * time.Minute,
+			wantThreshold:  60,
+			wantRecurrence: 30,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			contacts := uptimerobotv1.MonitorContacts{
+				{
+					ID: "123",
+					MonitorContactCommon: uptimerobotv1.MonitorContactCommon{
+						Threshold:  metav1.Duration{Duration: tc.threshold},
+						Recurrence: metav1.Duration{Duration: tc.recurrence},
+					},
+				},
+			}
+
+			got := contactsToV3Format(contacts)
+			if len(got) != 1 {
+				t.Fatalf("expected one entry, got %d", len(got))
+			}
+			if got[0].Threshold != tc.wantThreshold {
+				t.Errorf("threshold: got %d (minutes) want %d", got[0].Threshold, tc.wantThreshold)
+			}
+			if got[0].Recurrence != tc.wantRecurrence {
+				t.Errorf("recurrence: got %d (minutes) want %d", got[0].Recurrence, tc.wantRecurrence)
+			}
+		})
+	}
+}
+
+func TestContactsToV3Format_NegativeThresholdClamped(t *testing.T) {
+	t.Parallel()
+
+	contacts := uptimerobotv1.MonitorContacts{
+		{
+			ID: "123",
+			MonitorContactCommon: uptimerobotv1.MonitorContactCommon{
+				Threshold: metav1.Duration{Duration: -5 * time.Minute},
+			},
+		},
+	}
+
+	got := contactsToV3Format(contacts)
+	if len(got) != 1 || got[0].Threshold != 0 {
+		t.Fatalf("expected threshold clamped to 0, got %+v", got)
+	}
+}
+
+func TestContactsToV3Format_SkipsEntriesWithoutID(t *testing.T) {
+	t.Parallel()
+
+	contacts := uptimerobotv1.MonitorContacts{
+		{ID: ""},
+		{ID: "42", MonitorContactCommon: uptimerobotv1.MonitorContactCommon{
+			Threshold: metav1.Duration{Duration: 3 * time.Minute},
+		}},
+	}
+
+	got := contactsToV3Format(contacts)
+	if len(got) != 1 || got[0].AlertContactID != "42" || got[0].Threshold != 3 {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}

--- a/internal/uptimerobot/v3types.go
+++ b/internal/uptimerobot/v3types.go
@@ -140,7 +140,7 @@ type UpdateMonitorRequest struct {
 // Note: The v3 API uses camelCase field names and alertContactId is a string.
 type AssignedAlertContactRequest struct {
 	AlertContactID string `json:"alertContactId"` // Alert contact ID (string in v3)
-	Threshold      int    `json:"threshold"`      // Per-contact threshold in seconds
+	Threshold      int    `json:"threshold"`      // Per-contact threshold in MINUTES (UptimeRobot v3)
 	Recurrence     int    `json:"recurrence"`     // Minutes between repeat notifications (0 = disabled)
 }
 


### PR DESCRIPTION
contactsToV3Format was converting Monitor.spec.contacts[].threshold with .Seconds() while recurrence was converted with .Minutes(). The UptimeRobot v3 API actually reads both fields as minutes, so the CRDs default threshold of 1m was being sent as 60 and interpreted as 60 minutes - every operator-managed monitor was running with a 1-hour effective alert delay instead of 1 minute, visible as "1 hour delay, dont repeat" in the UptimeRobot UI.

- client.go: int(c.Threshold.Round(time.Minute).Minutes()), matching the existing recurrence conversion. Negative values still clamp to 0.
- v3types.go: correct the type comment (in seconds -> in MINUTES).
- client_contacts_v3_test.go: lock in minute semantics with table tests covering 1m default, multi-minute values, zero, sub-minute rounding on both sides of 30s, negative clamping, and empty-ID skip.

Fixes #188.