### PR TITLE
docs(readme): split docs into user and technical sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,22 +87,46 @@ EOF
 
 ## Documentation
 
+### User Documentation
+
+Guides focused on day-to-day usage and operations.
+
 | Document | Purpose |
 |----------|---------|
 | [Installation](docs/installation.md) | Install via kubectl or Helm |
 | [Getting Started](docs/getting-started.md) | Create your first monitor (tutorial) |
-| [Security](SECURITY.md) | Verify images and deployment best practices |
 | [Monitors](docs/monitors.md) | Configure monitor types and alerts |
 | [Monitor Groups](docs/monitor-groups.md) | Group monitors and manage membership declaratively |
-| [Slack Alerting](docs/slack-alerting.md) | Configure Slack integration and wire alerts to monitors |
-| [Metrics](docs/metrics.md) | Prometheus metrics and Grafana dashboards |
-| [Migration Guide](docs/migration-guide.md) | Adopt existing UptimeRobot resources |
 | [Maintenance Windows](docs/maintenance-windows.md) | Schedule planned downtime |
-| [Architecture](docs/architecture.md) | System architecture and data flows |
+| [Slack Alerting](docs/slack-alerting.md) | End-to-end Slack alert routing for monitors |
+| [Migration Guide](docs/migration-guide.md) | Adopt existing UptimeRobot resources |
 | [Troubleshooting](docs/troubleshooting.md) | Diagnose and fix common issues |
+
+#### CRD Guides
+
+Explicit documentation for each CRD type:
+
+| CRD | Guide |
+|-----|-------|
+| `Account` | [Configure Accounts](docs/accounts.md) |
+| `Contact` | [Configure Contacts](docs/contacts.md) |
+| `Monitor` | [Configure Monitors](docs/monitors.md) |
+| `MonitorGroup` | [Configure Monitor Groups](docs/monitor-groups.md) |
+| `MaintenanceWindow` | [Maintenance Windows](docs/maintenance-windows.md) |
+| `SlackIntegration` | [Configure Slack Integrations](docs/slack-integrations.md) |
+
+### Technical Documentation
+
+Design, API, and contributor-focused documentation.
+
+| Document | Purpose |
+|----------|---------|
+| [Architecture](docs/architecture.md) | System architecture and data flows |
+| [Metrics](docs/metrics.md) | Prometheus metrics and Grafana dashboards |
 | [API Versioning](docs/api-versioning.md) | API stability, deprecation, and upgrade policy |
 | [API Reference](docs/api-reference.md) | Complete CRD field reference |
-| [Development](docs/development.md) | Contributing and testing |
+| [Development](docs/development.md) | Local development and testing |
+| [Security](SECURITY.md) | Image verification and deployment security practices |
 
 ## Monitor Types
 

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -1,0 +1,82 @@
+# Configure Accounts
+
+Configure the `Account` custom resource to connect the operator to UptimeRobot.
+
+## What the Account resource does
+
+- Stores how the operator authenticates to UptimeRobot.
+- Exposes account metadata and available alert contacts in status.
+- Can be marked as the default account for other resources.
+
+`Account` is cluster-scoped.
+
+## Prerequisites
+
+- You have installed the operator.
+- You have an UptimeRobot API key.
+- You can create secrets in the `uptime-robot-system` namespace.
+
+## Create an API key secret
+
+```bash
+kubectl create secret generic uptimerobot-api-key \
+  --namespace uptime-robot-system \
+  --from-literal=apiKey=YOUR_API_KEY
+```
+
+## Create an Account resource
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Account
+metadata:
+  name: default
+spec:
+  isDefault: true
+  apiKeySecretRef:
+    name: uptimerobot-api-key
+    key: apiKey
+```
+
+Apply:
+
+```bash
+kubectl apply -f account.yaml
+```
+
+## Verify readiness
+
+```bash
+kubectl get account default -o jsonpath='{.status.ready}{"\n"}'
+```
+
+List available alert contacts:
+
+```bash
+kubectl get account default -o jsonpath='{range .status.alertContacts[*]}{.id}{"\t"}{.friendlyName}{"\t"}{.type}{"\n"}{end}'
+```
+
+## Use a non-default account
+
+If you manage multiple accounts, create additional `Account` resources and reference
+one explicitly from other resources:
+
+```yaml
+spec:
+  account:
+    name: production
+```
+
+## Troubleshooting
+
+- `Account` is not ready:
+  Check `kubectl describe account <name>` for API key or connectivity errors.
+- No contacts in `status.alertContacts`:
+  Confirm the API key has access to alert contacts in UptimeRobot.
+
+## Related guides
+
+- [Configure Contacts](contacts.md)
+- [Configure Monitors](monitors.md)
+- [Configure Slack Integrations](slack-integrations.md)
+- [API Reference](api-reference.md)

--- a/docs/contacts.md
+++ b/docs/contacts.md
@@ -1,0 +1,102 @@
+# Configure Contacts
+
+Configure the `Contact` custom resource to route monitor alerts to existing
+UptimeRobot alert contacts.
+
+## What the Contact resource does
+
+- Resolves an existing UptimeRobot alert contact by ID or friendly name.
+- Lets you set a reusable default contact for monitors.
+- Provides the resolved contact ID in status.
+
+`Contact` is cluster-scoped. Contacts are not created in UptimeRobot by this
+resource; they must already exist in your account.
+
+## Prerequisites
+
+- You have an `Account` resource that is `Ready`.
+- The target alert contact already exists in UptimeRobot.
+
+## Find available alert contacts
+
+```bash
+kubectl get account default -o jsonpath='{range .status.alertContacts[*]}{.id}{"\t"}{.friendlyName}{"\t"}{.type}{"\n"}{end}'
+```
+
+## Create a Contact by ID
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Contact
+metadata:
+  name: team-email
+spec:
+  contact:
+    id: "1234567"
+```
+
+## Create a Contact by friendly name
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Contact
+metadata:
+  name: team-email
+spec:
+  contact:
+    name: "Team Email"
+```
+
+Use either `id` or `name`, not both.
+
+## Set a default contact
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Contact
+metadata:
+  name: default
+spec:
+  isDefault: true
+  contact:
+    id: "1234567"
+```
+
+Monitors without `spec.contacts` use the default contact.
+
+## Verify readiness
+
+```bash
+kubectl get contact team-email -o jsonpath='{.status.ready}{"\t"}{.status.id}{"\n"}'
+```
+
+## Use a Contact from a Monitor
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: Monitor
+metadata:
+  name: api-health
+spec:
+  contacts:
+    - name: team-email
+      threshold: 1m
+      recurrence: 15m
+  monitor:
+    name: API Health
+    url: https://api.example.com/health
+```
+
+## Troubleshooting
+
+- `Contact` not ready:
+  Confirm the ID or friendly name exists in `Account.status.alertContacts`.
+- Ambiguous friendly name:
+  Use `spec.contact.id` instead of `spec.contact.name`.
+
+## Related guides
+
+- [Configure Accounts](accounts.md)
+- [Configure Monitors](monitors.md)
+- [Configure Slack Alerting for Monitors](slack-alerting.md)
+- [API Reference](api-reference.md)

--- a/docs/slack-integrations.md
+++ b/docs/slack-integrations.md
@@ -1,0 +1,80 @@
+# Configure Slack Integrations
+
+Configure the `SlackIntegration` custom resource to manage Slack webhook
+integrations in UptimeRobot.
+
+## What the SlackIntegration resource does
+
+- Creates and updates a Slack integration in UptimeRobot.
+- Stores integration state and resolved ID in status.
+- Makes Slack-backed contacts discoverable through `Account.status.alertContacts`.
+
+`SlackIntegration` is namespaced.
+
+## Prerequisites
+
+- You have installed the operator.
+- You have an `Account` resource that is `Ready`.
+- You have a Slack incoming webhook URL.
+
+## Create the webhook secret
+
+```bash
+kubectl create secret generic platform-alerts-webhook \
+  -n uptime-robot-system \
+  --from-literal=webhookURL='https://example.invalid/your-slack-webhook-url'
+```
+
+## Create a SlackIntegration resource
+
+```yaml
+apiVersion: uptimerobot.com/v1alpha1
+kind: SlackIntegration
+metadata:
+  name: platform-alerts
+  namespace: uptime-robot-system
+spec:
+  account:
+    name: default
+  syncInterval: 24h
+  prune: true
+  integration:
+    friendlyName: platform-alerts
+    secretName: platform-alerts-webhook
+    webhookURLKey: webhookURL
+    enableNotificationsFor: UpAndDown
+    sslExpirationReminder: true
+```
+
+Apply and verify:
+
+```bash
+kubectl apply -f slackintegration.yaml
+kubectl get slackintegration platform-alerts -n uptime-robot-system -o jsonpath='{.status.ready}{"\t"}{.status.id}{"\n"}'
+```
+
+## Connect Slack integration to monitors
+
+`Monitor` resources do not reference `SlackIntegration` directly. Use this flow:
+
+1. Create `SlackIntegration`.
+2. Create a `Contact` that points to the Slack contact ID or friendly name.
+3. Reference that `Contact` in `Monitor.spec.contacts`.
+
+For the full end-to-end workflow, see
+[Configure Slack Alerting for Monitors](slack-alerting.md).
+
+## Troubleshooting
+
+- `SlackIntegration` not ready:
+  Check `kubectl describe slackintegration <name> -n <namespace>` for
+  account, webhook, or API validation errors.
+- Slack contact missing from account status:
+  Wait for reconciliation and confirm the referenced account is `Ready`.
+
+## Related guides
+
+- [Configure Slack Alerting for Monitors](slack-alerting.md)
+- [Configure Contacts](contacts.md)
+- [Configure Monitors](monitors.md)
+- [API Reference](api-reference.md)


### PR DESCRIPTION
Add dedicated CRD guides for Account, Contact, and SlackIntegration. Reorganize README documentation links to separate user workflows from under-the-hood technical material.