### PR TITLE
fix: refresh ObservedGeneration on blocked circuit-breaker conditions 

### DIFF
--- a/internal/controller/circuit_breaker_status.go
+++ b/internal/controller/circuit_breaker_status.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/controller/circuit_breaker_status.go
+++ b/internal/controller/circuit_breaker_status.go
@@ -3,18 +3,52 @@ package controller
 import (
 	"fmt"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func circuitBreakerBlockDetails(accountKey string, state CircuitState, cooldown time.Duration) (reason, eventReason, msg string) {
 	switch state {
 	case CircuitOpen:
-		return ReasonCircuitBreakerOpen, "CircuitBreakerOpen",
+		return ReasonCircuitBreakerOpen, ReasonCircuitBreakerOpen,
 			fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
 	case CircuitHalfOpen:
-		return ReasonCircuitBreakerBlocked, "CircuitBreakerBlocked",
+		return ReasonCircuitBreakerBlocked, ReasonCircuitBreakerBlocked,
 			fmt.Sprintf("Circuit breaker half-open for account %s; probe request already in flight, reconciliation temporarily paused (retrying in %s)", accountKey, cooldown)
 	default:
-		return ReasonCircuitBreakerBlocked, "CircuitBreakerBlocked",
+		return ReasonCircuitBreakerBlocked, ReasonCircuitBreakerBlocked,
 			fmt.Sprintf("Circuit breaker blocking API call for account %s in state %s; reconciliation temporarily paused (retrying in %s)", accountKey, state, cooldown)
 	}
+}
+
+// applyCircuitBreakerBlockedConditions ensures Ready/Synced/Error reflect a
+// blocked circuit-breaker state for the given object generation. Returns the
+// event reason, the message, and changed=true only on transition into the
+// blocked state (including when the spec generation advances while blocked),
+// so callers emit the warning event and persist status exactly once per
+// transition rather than on every requeue tick.
+func applyCircuitBreakerBlockedConditions(conditions *[]metav1.Condition, generation int64, accountKey string, state CircuitState, cooldown time.Duration) (eventReason, msg string, changed bool) {
+	reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+	alreadyBlocked := blockedConditionMatches(*conditions, TypeSynced, metav1.ConditionFalse, reason, msg, generation) &&
+		blockedConditionMatches(*conditions, TypeReady, metav1.ConditionFalse, reason, msg, generation) &&
+		blockedConditionMatches(*conditions, TypeError, metav1.ConditionTrue, reason, msg, generation)
+	if alreadyBlocked {
+		return eventReason, msg, false
+	}
+	SetReadyCondition(conditions, false, reason, msg, generation)
+	SetSyncedCondition(conditions, false, reason, msg, generation)
+	SetErrorCondition(conditions, true, reason, msg, generation)
+	return eventReason, msg, true
+}
+
+// blockedConditionMatches is like conditionMatches but also requires the
+// stored ObservedGeneration to match. This ensures a spec edit during an open
+// breaker is treated as a new transition so ObservedGeneration gets refreshed.
+func blockedConditionMatches(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus, reason, message string, generation int64) bool {
+	for _, c := range conditions {
+		if c.Type == conditionType {
+			return c.Status == status && c.Reason == reason && c.Message == message && c.ObservedGeneration == generation
+		}
+	}
+	return false
 }

--- a/internal/controller/circuit_breaker_status.go
+++ b/internal/controller/circuit_breaker_status.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+)
+
+func circuitBreakerBlockDetails(accountKey string, state CircuitState, cooldown time.Duration) (reason, eventReason, msg string) {
+	switch state {
+	case CircuitOpen:
+		return ReasonCircuitBreakerOpen, "CircuitBreakerOpen",
+			fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
+	case CircuitHalfOpen:
+		return ReasonCircuitBreakerBlocked, "CircuitBreakerBlocked",
+			fmt.Sprintf("Circuit breaker half-open for account %s; probe request already in flight, reconciliation temporarily paused (retrying in %s)", accountKey, cooldown)
+	default:
+		return ReasonCircuitBreakerBlocked, "CircuitBreakerBlocked",
+			fmt.Sprintf("Circuit breaker blocking API call for account %s in state %s; reconciliation temporarily paused (retrying in %s)", accountKey, state, cooldown)
+	}
+}

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -56,6 +56,10 @@ const (
 	// ReasonCircuitBreakerOpen indicates reconciliation is paused while the API
 	// circuit breaker is open.
 	ReasonCircuitBreakerOpen = "CircuitBreakerOpen"
+	// ReasonCircuitBreakerBlocked indicates reconciliation is paused while the API
+	// circuit breaker is blocking calls in a non-open state (for example,
+	// half-open while a probe is already in flight).
+	ReasonCircuitBreakerBlocked = "CircuitBreakerBlocked"
 )
 
 // SetCondition sets or updates a condition in the conditions list

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -53,6 +53,9 @@ const (
 	ReasonSecretNotFound = "SecretNotFound"
 	// ReasonDependencyNotReady indicates a referenced dependency is not ready yet
 	ReasonDependencyNotReady = "DependencyNotReady"
+	// ReasonCircuitBreakerOpen indicates reconciliation is paused while the API
+	// circuit breaker is open.
+	ReasonCircuitBreakerOpen = "CircuitBreakerOpen"
 )
 
 // SetCondition sets or updates a condition in the conditions list

--- a/internal/controller/maintenancewindow_controller.go
+++ b/internal/controller/maintenancewindow_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -180,8 +181,25 @@ func (r *MaintenanceWindowReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
-		log.FromContext(ctx).Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
-		return ctrl.Result{RequeueAfter: DefaultCircuitBreaker.CooldownPeriod()}, nil
+		logger := log.FromContext(ctx)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		cooldown := DefaultCircuitBreaker.CooldownPeriod()
+		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
+		alreadyBlocked := conditionMatches(mw.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(mw.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(mw.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		if !alreadyBlocked {
+			SetReadyCondition(&mw.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, mw.Generation)
+			SetSyncedCondition(&mw.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, mw.Generation)
+			SetErrorCondition(&mw.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, mw.Generation)
+			if r.Recorder != nil {
+				r.Recorder.Event(mw, "Warning", "CircuitBreakerOpen", msg)
+			}
+			if updateErr := r.updateMaintenanceWindowStatus(ctx, mw); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+		}
+		return ctrl.Result{RequeueAfter: cooldown}, nil
 	}
 
 	// Add finalizer before creating external resource to prevent orphaning

--- a/internal/controller/maintenancewindow_controller.go
+++ b/internal/controller/maintenancewindow_controller.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -184,14 +183,8 @@ func (r *MaintenanceWindowReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		state := DefaultCircuitBreaker.State(accountKey)
 		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
-		alreadyBlocked := conditionMatches(mw.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(mw.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(mw.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
-		if !alreadyBlocked {
-			SetReadyCondition(&mw.Status.Conditions, false, reason, msg, mw.Generation)
-			SetSyncedCondition(&mw.Status.Conditions, false, reason, msg, mw.Generation)
-			SetErrorCondition(&mw.Status.Conditions, true, reason, msg, mw.Generation)
+		eventReason, msg, changed := applyCircuitBreakerBlockedConditions(&mw.Status.Conditions, mw.Generation, accountKey, state, cooldown)
+		if changed {
 			if r.Recorder != nil {
 				r.Recorder.Event(mw, "Warning", eventReason, msg)
 			}

--- a/internal/controller/maintenancewindow_controller.go
+++ b/internal/controller/maintenancewindow_controller.go
@@ -181,19 +181,19 @@ func (r *MaintenanceWindowReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
-		logger := log.FromContext(ctx)
-		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		state := DefaultCircuitBreaker.State(accountKey)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
-		alreadyBlocked := conditionMatches(mw.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(mw.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(mw.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+		alreadyBlocked := conditionMatches(mw.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(mw.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(mw.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
 		if !alreadyBlocked {
-			SetReadyCondition(&mw.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, mw.Generation)
-			SetSyncedCondition(&mw.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, mw.Generation)
-			SetErrorCondition(&mw.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, mw.Generation)
+			SetReadyCondition(&mw.Status.Conditions, false, reason, msg, mw.Generation)
+			SetSyncedCondition(&mw.Status.Conditions, false, reason, msg, mw.Generation)
+			SetErrorCondition(&mw.Status.Conditions, true, reason, msg, mw.Generation)
 			if r.Recorder != nil {
-				r.Recorder.Event(mw, "Warning", "CircuitBreakerOpen", msg)
+				r.Recorder.Event(mw, "Warning", eventReason, msg)
 			}
 			if updateErr := r.updateMaintenanceWindowStatus(ctx, mw); updateErr != nil {
 				return ctrl.Result{}, updateErr

--- a/internal/controller/maintenancewindow_controller_test.go
+++ b/internal/controller/maintenancewindow_controller_test.go
@@ -147,6 +147,105 @@ var _ = Describe("MaintenanceWindow Controller", func() {
 			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
 		})
 
+		It("should flag Ready/Synced/Error when circuit breaker blocks and recover when it closes", func() {
+			mw := CreateMaintenanceWindow(ctx, "test-circuit-breaker-mw", account.Name, uptimerobotv1.MaintenanceWindowSpec{
+				Name:      "Circuit Breaker MW",
+				Interval:  "daily",
+				StartTime: "02:00:00",
+				Duration:  metav1.Duration{Duration: time.Hour},
+			})
+			defer CleanupMaintenanceWindow(ctx, mw)
+
+			recorder := record.NewFakeRecorder(10)
+			reconciler := &MaintenanceWindowReconciler{
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  recorder,
+			}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: mw.Name, Namespace: mw.Namespace}}
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			origBreaker := DefaultCircuitBreaker
+			const cooldown = 10 * time.Second
+			DefaultCircuitBreaker = NewCircuitBreaker(1, cooldown)
+			DeferCleanup(func() {
+				DefaultCircuitBreaker = origBreaker
+			})
+
+			accountKey := account.Name
+			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
+			state := DefaultCircuitBreaker.State(accountKey)
+			reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+
+			Expect(k8sClient.Get(ctx, req.NamespacedName, mw)).To(Succeed())
+			ready := findCondition(mw.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(reason))
+			Expect(ready.Message).To(Equal(msg))
+			firstReadyTransition := ready.LastTransitionTime
+
+			synced := findCondition(mw.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionFalse))
+			Expect(synced.Reason).To(Equal(reason))
+			Expect(synced.Message).To(Equal(msg))
+			firstSyncedTransition := synced.LastTransitionTime
+
+			errCond := findCondition(mw.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errCond.Reason).To(Equal(reason))
+			Expect(errCond.Message).To(Equal(msg))
+			firstErrorTransition := errCond.LastTransitionTime
+
+			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(
+				And(ContainSubstring(eventReason), ContainSubstring(accountKey)),
+			))
+
+			result, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+			Expect(k8sClient.Get(ctx, req.NamespacedName, mw)).To(Succeed())
+			ready = findCondition(mw.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.LastTransitionTime).To(Equal(firstReadyTransition))
+			synced = findCondition(mw.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.LastTransitionTime).To(Equal(firstSyncedTransition))
+			errCond = findCondition(mw.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.LastTransitionTime).To(Equal(firstErrorTransition))
+			Consistently(recorder.Events, 200*time.Millisecond, 50*time.Millisecond).ShouldNot(Receive())
+
+			Expect(DefaultCircuitBreaker.RecordSuccess(accountKey)).To(BeTrue())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, req.NamespacedName, mw)).To(Succeed())
+
+			ready = findCondition(mw.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(ReasonReconcileSuccess))
+
+			synced = findCondition(mw.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionTrue))
+			Expect(synced.Reason).To(Equal(ReasonSyncSuccess))
+
+			errCond = findCondition(mw.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errCond.Reason).To(Equal(ReasonReconcileSuccess))
+		})
+
 		It("should update maintenance window successfully", func() {
 			mw := CreateMaintenanceWindow(ctx, "test-update-mw", account.Name, uptimerobotv1.MaintenanceWindowSpec{
 				Name:      "Test Update MW",

--- a/internal/controller/maintenancewindow_controller_test.go
+++ b/internal/controller/maintenancewindow_controller_test.go
@@ -177,8 +177,9 @@ var _ = Describe("MaintenanceWindow Controller", func() {
 
 			accountKey := account.Name
 			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
-			state := DefaultCircuitBreaker.State(accountKey)
-			reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+			reason := ReasonCircuitBreakerOpen
+			eventReason := ReasonCircuitBreakerOpen
+			msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
 
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/monitor_controller.go
+++ b/internal/controller/monitor_controller.go
@@ -254,14 +254,8 @@ func (r *MonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		state := DefaultCircuitBreaker.State(accountKey)
 		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
-		alreadyBlocked := conditionMatches(monitor.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(monitor.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(monitor.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
-		if !alreadyBlocked {
-			SetReadyCondition(&monitor.Status.Conditions, false, reason, msg, monitor.Generation)
-			SetSyncedCondition(&monitor.Status.Conditions, false, reason, msg, monitor.Generation)
-			SetErrorCondition(&monitor.Status.Conditions, true, reason, msg, monitor.Generation)
+		eventReason, msg, changed := applyCircuitBreakerBlockedConditions(&monitor.Status.Conditions, monitor.Generation, accountKey, state, cooldown)
+		if changed {
 			if r.Recorder != nil {
 				r.Recorder.Event(monitor, "Warning", eventReason, msg)
 			}

--- a/internal/controller/monitor_controller.go
+++ b/internal/controller/monitor_controller.go
@@ -251,18 +251,19 @@ func (r *MonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
 		logger := log.FromContext(ctx)
-		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		state := DefaultCircuitBreaker.State(accountKey)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
-		alreadyBlocked := conditionMatches(monitor.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(monitor.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(monitor.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+		alreadyBlocked := conditionMatches(monitor.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(monitor.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(monitor.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
 		if !alreadyBlocked {
-			SetReadyCondition(&monitor.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, monitor.Generation)
-			SetSyncedCondition(&monitor.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, monitor.Generation)
-			SetErrorCondition(&monitor.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, monitor.Generation)
+			SetReadyCondition(&monitor.Status.Conditions, false, reason, msg, monitor.Generation)
+			SetSyncedCondition(&monitor.Status.Conditions, false, reason, msg, monitor.Generation)
+			SetErrorCondition(&monitor.Status.Conditions, true, reason, msg, monitor.Generation)
 			if r.Recorder != nil {
-				r.Recorder.Event(monitor, "Warning", "CircuitBreakerOpen", msg)
+				r.Recorder.Event(monitor, "Warning", eventReason, msg)
 			}
 			if updateErr := r.updateMonitorStatus(ctx, monitor); updateErr != nil {
 				return ctrl.Result{}, updateErr

--- a/internal/controller/monitor_controller.go
+++ b/internal/controller/monitor_controller.go
@@ -250,8 +250,25 @@ func (r *MonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
-		log.FromContext(ctx).Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
-		return ctrl.Result{RequeueAfter: DefaultCircuitBreaker.CooldownPeriod()}, nil
+		logger := log.FromContext(ctx)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		cooldown := DefaultCircuitBreaker.CooldownPeriod()
+		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
+		alreadyBlocked := conditionMatches(monitor.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(monitor.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(monitor.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		if !alreadyBlocked {
+			SetReadyCondition(&monitor.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, monitor.Generation)
+			SetSyncedCondition(&monitor.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, monitor.Generation)
+			SetErrorCondition(&monitor.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, monitor.Generation)
+			if r.Recorder != nil {
+				r.Recorder.Event(monitor, "Warning", "CircuitBreakerOpen", msg)
+			}
+			if updateErr := r.updateMonitorStatus(ctx, monitor); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+		}
+		return ctrl.Result{RequeueAfter: cooldown}, nil
 	}
 
 	if !controllerutil.ContainsFinalizer(monitor, myFinalizerName) {

--- a/internal/controller/monitor_controller_test.go
+++ b/internal/controller/monitor_controller_test.go
@@ -340,7 +340,7 @@ var _ = Describe("Monitor Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			origBreaker := DefaultCircuitBreaker
-			const cooldown = time.Hour
+			const cooldown = 10 * time.Second
 			DefaultCircuitBreaker = NewCircuitBreaker(1, cooldown)
 			DeferCleanup(func() {
 				DefaultCircuitBreaker = origBreaker
@@ -370,12 +370,14 @@ var _ = Describe("Monitor Controller", func() {
 			Expect(synced.Status).To(Equal(metav1.ConditionFalse))
 			Expect(synced.Reason).To(Equal(ReasonCircuitBreakerOpen))
 			Expect(synced.Message).To(Equal(msg))
+			firstSyncedTransition := synced.LastTransitionTime
 
 			errCond := findCondition(monitor.Status.Conditions, TypeError)
 			Expect(errCond).NotTo(BeNil())
 			Expect(errCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(errCond.Reason).To(Equal(ReasonCircuitBreakerOpen))
 			Expect(errCond.Message).To(Equal(msg))
+			firstErrorTransition := errCond.LastTransitionTime
 
 			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(
 				And(ContainSubstring("CircuitBreakerOpen"), ContainSubstring(accountKey)),
@@ -390,6 +392,14 @@ var _ = Describe("Monitor Controller", func() {
 			ready = findCondition(monitor.Status.Conditions, TypeReady)
 			Expect(ready).NotTo(BeNil())
 			Expect(ready.LastTransitionTime).To(Equal(firstReadyTransition))
+			synced = findCondition(monitor.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.LastTransitionTime).To(Equal(firstSyncedTransition))
+			errCond = findCondition(monitor.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.LastTransitionTime).To(Equal(firstErrorTransition))
+			// Use a short window to prove we don't emit repeat warning events on
+			// tight requeue loops while the circuit remains open.
 			Consistently(recorder.Events, 200*time.Millisecond, 50*time.Millisecond).ShouldNot(Receive())
 
 			Expect(DefaultCircuitBreaker.RecordSuccess(accountKey)).To(BeTrue())

--- a/internal/controller/monitor_controller_test.go
+++ b/internal/controller/monitor_controller_test.go
@@ -426,6 +426,56 @@ var _ = Describe("Monitor Controller", func() {
 			Expect(errCond.Reason).To(Equal(ReasonReconcileSuccess))
 		})
 
+		It("should refresh ObservedGeneration on blocked conditions when spec changes while circuit is open", func() {
+			recorder := record.NewFakeRecorder(10)
+			controllerReconciler := &MonitorReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			origBreaker := DefaultCircuitBreaker
+			const cooldown = 10 * time.Second
+			DefaultCircuitBreaker = NewCircuitBreaker(1, cooldown)
+			DeferCleanup(func() { DefaultCircuitBreaker = origBreaker })
+
+			accountKey := account.Name
+			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+			gen1 := monitor.Generation
+			ready := findCondition(monitor.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.ObservedGeneration).To(Equal(gen1))
+			firstTransition := ready.LastTransitionTime
+
+			By("mutating the monitor spec so generation advances while the breaker is still open")
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+			monitor.Spec.Monitor.Name = "renamed-while-blocked"
+			Expect(k8sClient.Update(ctx, monitor)).To(Succeed())
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+			gen2 := monitor.Generation
+			Expect(gen2).To(BeNumerically(">", gen1))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+
+			for _, t := range []string{TypeReady, TypeSynced, TypeError} {
+				c := findCondition(monitor.Status.Conditions, t)
+				Expect(c).NotTo(BeNil())
+				Expect(c.ObservedGeneration).To(Equal(gen2), "ObservedGeneration must advance with spec generation even while blocked (type=%s)", t)
+			}
+			// Reason/message unchanged -> LastTransitionTime must NOT bump.
+			ready = findCondition(monitor.Status.Conditions, TypeReady)
+			Expect(ready.LastTransitionTime).To(Equal(firstTransition))
+		})
+
 		It("should preserve status.ready when type-change delete fails", func() {
 			controllerReconciler := &MonitorReconciler{
 				Client: k8sClient,

--- a/internal/controller/monitor_controller_test.go
+++ b/internal/controller/monitor_controller_test.go
@@ -326,6 +326,96 @@ var _ = Describe("Monitor Controller", func() {
 			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
 		})
 
+		It("should flag Ready/Synced/Error when circuit breaker is open and recover when it closes", func() {
+			recorder := record.NewFakeRecorder(10)
+			controllerReconciler := &MonitorReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			origBreaker := DefaultCircuitBreaker
+			const cooldown = time.Hour
+			DefaultCircuitBreaker = NewCircuitBreaker(1, cooldown)
+			DeferCleanup(func() {
+				DefaultCircuitBreaker = origBreaker
+			})
+
+			accountKey := account.Name
+			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
+			msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+
+			ready := findCondition(monitor.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(ReasonCircuitBreakerOpen))
+			Expect(ready.Message).To(Equal(msg))
+			firstReadyTransition := ready.LastTransitionTime
+
+			synced := findCondition(monitor.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionFalse))
+			Expect(synced.Reason).To(Equal(ReasonCircuitBreakerOpen))
+			Expect(synced.Message).To(Equal(msg))
+
+			errCond := findCondition(monitor.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errCond.Reason).To(Equal(ReasonCircuitBreakerOpen))
+			Expect(errCond.Message).To(Equal(msg))
+
+			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(
+				And(ContainSubstring("CircuitBreakerOpen"), ContainSubstring(accountKey)),
+			))
+
+			result, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+			ready = findCondition(monitor.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.LastTransitionTime).To(Equal(firstReadyTransition))
+			Consistently(recorder.Events, 200*time.Millisecond, 50*time.Millisecond).ShouldNot(Receive())
+
+			Expect(DefaultCircuitBreaker.RecordSuccess(accountKey)).To(BeTrue())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, namespacedName, monitor)).To(Succeed())
+
+			ready = findCondition(monitor.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(ReasonReconcileSuccess))
+
+			synced = findCondition(monitor.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionTrue))
+			Expect(synced.Reason).To(Equal(ReasonSyncSuccess))
+
+			errCond = findCondition(monitor.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errCond.Reason).To(Equal(ReasonReconcileSuccess))
+		})
+
 		It("should preserve status.ready when type-change delete fails", func() {
 			controllerReconciler := &MonitorReconciler{
 				Client: k8sClient,

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -185,8 +185,25 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
-		log.FromContext(ctx).Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
-		return ctrl.Result{RequeueAfter: DefaultCircuitBreaker.CooldownPeriod()}, nil
+		logger := log.FromContext(ctx)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		cooldown := DefaultCircuitBreaker.CooldownPeriod()
+		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
+		alreadyBlocked := conditionMatches(groupResource.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(groupResource.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(groupResource.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		if !alreadyBlocked {
+			SetReadyCondition(&groupResource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, groupResource.Generation)
+			SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, groupResource.Generation)
+			SetErrorCondition(&groupResource.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, groupResource.Generation)
+			if r.Recorder != nil {
+				r.Recorder.Event(groupResource, "Warning", "CircuitBreakerOpen", msg)
+			}
+			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+		}
+		return ctrl.Result{RequeueAfter: cooldown}, nil
 	}
 
 	// Step 5: Attach finalizer for cleanup tracking

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -185,19 +185,19 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
-		logger := log.FromContext(ctx)
-		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		state := DefaultCircuitBreaker.State(accountKey)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
-		alreadyBlocked := conditionMatches(groupResource.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(groupResource.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(groupResource.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+		alreadyBlocked := conditionMatches(groupResource.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(groupResource.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(groupResource.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
 		if !alreadyBlocked {
-			SetReadyCondition(&groupResource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, groupResource.Generation)
-			SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, groupResource.Generation)
-			SetErrorCondition(&groupResource.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, groupResource.Generation)
+			SetReadyCondition(&groupResource.Status.Conditions, false, reason, msg, groupResource.Generation)
+			SetSyncedCondition(&groupResource.Status.Conditions, false, reason, msg, groupResource.Generation)
+			SetErrorCondition(&groupResource.Status.Conditions, true, reason, msg, groupResource.Generation)
 			if r.Recorder != nil {
-				r.Recorder.Event(groupResource, "Warning", "CircuitBreakerOpen", msg)
+				r.Recorder.Event(groupResource, "Warning", eventReason, msg)
 			}
 			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
 				return ctrl.Result{}, updateErr

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -188,14 +188,8 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		state := DefaultCircuitBreaker.State(accountKey)
 		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
-		alreadyBlocked := conditionMatches(groupResource.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(groupResource.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(groupResource.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
-		if !alreadyBlocked {
-			SetReadyCondition(&groupResource.Status.Conditions, false, reason, msg, groupResource.Generation)
-			SetSyncedCondition(&groupResource.Status.Conditions, false, reason, msg, groupResource.Generation)
-			SetErrorCondition(&groupResource.Status.Conditions, true, reason, msg, groupResource.Generation)
+		eventReason, msg, changed := applyCircuitBreakerBlockedConditions(&groupResource.Status.Conditions, groupResource.Generation, accountKey, state, cooldown)
+		if changed {
 			if r.Recorder != nil {
 				r.Recorder.Event(groupResource, "Warning", eventReason, msg)
 			}

--- a/internal/controller/monitorgroup_controller_test.go
+++ b/internal/controller/monitorgroup_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -118,8 +119,9 @@ var _ = Describe("MonitorGroup Controller", func() {
 
 			accountKey := account.Name
 			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
-			state := DefaultCircuitBreaker.State(accountKey)
-			reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+			reason := ReasonCircuitBreakerOpen
+			eventReason := ReasonCircuitBreakerOpen
+			msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
 
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/monitorgroup_controller_test.go
+++ b/internal/controller/monitorgroup_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,6 +90,101 @@ var _ = Describe("MonitorGroup Controller", func() {
 			errCond := findCondition(mg.Status.Conditions, TypeError)
 			Expect(errCond).NotTo(BeNil())
 			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("should flag Ready/Synced/Error when circuit breaker blocks and recover when it closes", func() {
+			mg := CreateMonitorGroup(ctx, "test-circuit-breaker-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Circuit Breaker Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			recorder := record.NewFakeRecorder(10)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}}
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			origBreaker := DefaultCircuitBreaker
+			const cooldown = 10 * time.Second
+			DefaultCircuitBreaker = NewCircuitBreaker(1, cooldown)
+			DeferCleanup(func() {
+				DefaultCircuitBreaker = origBreaker
+			})
+
+			accountKey := account.Name
+			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
+			state := DefaultCircuitBreaker.State(accountKey)
+			reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+
+			Expect(k8sClient.Get(ctx, req.NamespacedName, mg)).To(Succeed())
+			ready := findCondition(mg.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(reason))
+			Expect(ready.Message).To(Equal(msg))
+			firstReadyTransition := ready.LastTransitionTime
+
+			synced := findCondition(mg.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionFalse))
+			Expect(synced.Reason).To(Equal(reason))
+			Expect(synced.Message).To(Equal(msg))
+			firstSyncedTransition := synced.LastTransitionTime
+
+			errCond := findCondition(mg.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errCond.Reason).To(Equal(reason))
+			Expect(errCond.Message).To(Equal(msg))
+			firstErrorTransition := errCond.LastTransitionTime
+
+			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(
+				And(ContainSubstring(eventReason), ContainSubstring(accountKey)),
+			))
+
+			result, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+			Expect(k8sClient.Get(ctx, req.NamespacedName, mg)).To(Succeed())
+			ready = findCondition(mg.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.LastTransitionTime).To(Equal(firstReadyTransition))
+			synced = findCondition(mg.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.LastTransitionTime).To(Equal(firstSyncedTransition))
+			errCond = findCondition(mg.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.LastTransitionTime).To(Equal(firstErrorTransition))
+			Consistently(recorder.Events, 200*time.Millisecond, 50*time.Millisecond).ShouldNot(Receive())
+
+			Expect(DefaultCircuitBreaker.RecordSuccess(accountKey)).To(BeTrue())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, req.NamespacedName, mg)).To(Succeed())
+
+			ready = findCondition(mg.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(ReasonReconcileSuccess))
+
+			synced = findCondition(mg.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionTrue))
+			Expect(synced.Reason).To(Equal(ReasonSyncSuccess))
+
+			errCond = findCondition(mg.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errCond.Reason).To(Equal(ReasonReconcileSuccess))
 		})
 
 		It("should update monitor group name successfully", func() {

--- a/internal/controller/slackintegration_controller.go
+++ b/internal/controller/slackintegration_controller.go
@@ -172,18 +172,19 @@ func (r *SlackIntegrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
 		logger := log.FromContext(ctx)
-		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		state := DefaultCircuitBreaker.State(accountKey)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
-		alreadyBlocked := conditionMatches(resource.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(resource.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
-			conditionMatches(resource.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+		alreadyBlocked := conditionMatches(resource.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(resource.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
+			conditionMatches(resource.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
 		if !alreadyBlocked {
-			SetReadyCondition(&resource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, resource.Generation)
-			SetSyncedCondition(&resource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, resource.Generation)
-			SetErrorCondition(&resource.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, resource.Generation)
+			SetReadyCondition(&resource.Status.Conditions, false, reason, msg, resource.Generation)
+			SetSyncedCondition(&resource.Status.Conditions, false, reason, msg, resource.Generation)
+			SetErrorCondition(&resource.Status.Conditions, true, reason, msg, resource.Generation)
 			if r.Recorder != nil {
-				r.Recorder.Event(resource, "Warning", "CircuitBreakerOpen", msg)
+				r.Recorder.Event(resource, "Warning", eventReason, msg)
 			}
 			if updateErr := r.updateSlackIntegrationStatus(ctx, resource); updateErr != nil {
 				return ctrl.Result{}, updateErr

--- a/internal/controller/slackintegration_controller.go
+++ b/internal/controller/slackintegration_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/joelp172/uptime-robot-operator/internal/uptimerobot"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -175,14 +174,8 @@ func (r *SlackIntegrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		state := DefaultCircuitBreaker.State(accountKey)
 		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", state)
 		cooldown := DefaultCircuitBreaker.CooldownPeriod()
-		reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
-		alreadyBlocked := conditionMatches(resource.Status.Conditions, TypeSynced, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(resource.Status.Conditions, TypeReady, metav1.ConditionFalse, reason, msg) &&
-			conditionMatches(resource.Status.Conditions, TypeError, metav1.ConditionTrue, reason, msg)
-		if !alreadyBlocked {
-			SetReadyCondition(&resource.Status.Conditions, false, reason, msg, resource.Generation)
-			SetSyncedCondition(&resource.Status.Conditions, false, reason, msg, resource.Generation)
-			SetErrorCondition(&resource.Status.Conditions, true, reason, msg, resource.Generation)
+		eventReason, msg, changed := applyCircuitBreakerBlockedConditions(&resource.Status.Conditions, resource.Generation, accountKey, state, cooldown)
+		if changed {
 			if r.Recorder != nil {
 				r.Recorder.Event(resource, "Warning", eventReason, msg)
 			}

--- a/internal/controller/slackintegration_controller.go
+++ b/internal/controller/slackintegration_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/joelp172/uptime-robot-operator/internal/uptimerobot"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -170,8 +171,25 @@ func (r *SlackIntegrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
-		log.FromContext(ctx).Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
-		return ctrl.Result{RequeueAfter: DefaultCircuitBreaker.CooldownPeriod()}, nil
+		logger := log.FromContext(ctx)
+		logger.Info("Circuit breaker blocking API call", "account", accountKey, "state", DefaultCircuitBreaker.State(accountKey))
+		cooldown := DefaultCircuitBreaker.CooldownPeriod()
+		msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
+		alreadyBlocked := conditionMatches(resource.Status.Conditions, TypeSynced, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(resource.Status.Conditions, TypeReady, metav1.ConditionFalse, ReasonCircuitBreakerOpen, msg) &&
+			conditionMatches(resource.Status.Conditions, TypeError, metav1.ConditionTrue, ReasonCircuitBreakerOpen, msg)
+		if !alreadyBlocked {
+			SetReadyCondition(&resource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, resource.Generation)
+			SetSyncedCondition(&resource.Status.Conditions, false, ReasonCircuitBreakerOpen, msg, resource.Generation)
+			SetErrorCondition(&resource.Status.Conditions, true, ReasonCircuitBreakerOpen, msg, resource.Generation)
+			if r.Recorder != nil {
+				r.Recorder.Event(resource, "Warning", "CircuitBreakerOpen", msg)
+			}
+			if updateErr := r.updateSlackIntegrationStatus(ctx, resource); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+		}
+		return ctrl.Result{RequeueAfter: cooldown}, nil
 	}
 
 	// Persist finalizer before any remote create/recreate calls to prevent orphaned integrations.

--- a/internal/controller/slackintegration_controller_test.go
+++ b/internal/controller/slackintegration_controller_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,6 +284,103 @@ var _ = Describe("SlackIntegration Controller", func() {
 			Expect(errCond).NotTo(BeNil())
 			Expect(errCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(errCond.Reason).To(Equal(ReasonAPIError))
+		})
+
+		It("should flag Ready/Synced/Error when circuit breaker blocks and recover when it closes", func() {
+			recorder := record.NewFakeRecorder(10)
+			controllerReconciler := &SlackIntegrationReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			origBreaker := DefaultCircuitBreaker
+			const cooldown = 10 * time.Second
+			DefaultCircuitBreaker = NewCircuitBreaker(1, cooldown)
+			DeferCleanup(func() {
+				DefaultCircuitBreaker = origBreaker
+			})
+
+			accountKey := account.Name
+			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
+			state := DefaultCircuitBreaker.State(accountKey)
+			reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+
+			Expect(k8sClient.Get(ctx, namespacedName, slackIntegration)).To(Succeed())
+			ready := findCondition(slackIntegration.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(reason))
+			Expect(ready.Message).To(Equal(msg))
+			firstReadyTransition := ready.LastTransitionTime
+
+			synced := findCondition(slackIntegration.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionFalse))
+			Expect(synced.Reason).To(Equal(reason))
+			Expect(synced.Message).To(Equal(msg))
+			firstSyncedTransition := synced.LastTransitionTime
+
+			errCond := findCondition(slackIntegration.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errCond.Reason).To(Equal(reason))
+			Expect(errCond.Message).To(Equal(msg))
+			firstErrorTransition := errCond.LastTransitionTime
+
+			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(
+				And(ContainSubstring(eventReason), ContainSubstring(accountKey)),
+			))
+
+			result, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+			Expect(k8sClient.Get(ctx, namespacedName, slackIntegration)).To(Succeed())
+			ready = findCondition(slackIntegration.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.LastTransitionTime).To(Equal(firstReadyTransition))
+			synced = findCondition(slackIntegration.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.LastTransitionTime).To(Equal(firstSyncedTransition))
+			errCond = findCondition(slackIntegration.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.LastTransitionTime).To(Equal(firstErrorTransition))
+			Consistently(recorder.Events, 200*time.Millisecond, 50*time.Millisecond).ShouldNot(Receive())
+
+			Expect(DefaultCircuitBreaker.RecordSuccess(accountKey)).To(BeTrue())
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, namespacedName, slackIntegration)).To(Succeed())
+
+			ready = findCondition(slackIntegration.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(ReasonReconcileSuccess))
+
+			synced = findCondition(slackIntegration.Status.Conditions, TypeSynced)
+			Expect(synced).NotTo(BeNil())
+			Expect(synced.Status).To(Equal(metav1.ConditionTrue))
+			Expect(synced.Reason).To(Equal(ReasonSyncSuccess))
+
+			errCond = findCondition(slackIntegration.Status.Conditions, TypeError)
+			Expect(errCond).NotTo(BeNil())
+			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errCond.Reason).To(Equal(ReasonReconcileSuccess))
 		})
 
 		It("should preserve status.ready when api key lookup fails for an existing resource", func() {

--- a/internal/controller/slackintegration_controller_test.go
+++ b/internal/controller/slackintegration_controller_test.go
@@ -308,8 +308,9 @@ var _ = Describe("SlackIntegration Controller", func() {
 
 			accountKey := account.Name
 			Expect(DefaultCircuitBreaker.RecordFailure(accountKey)).To(BeTrue())
-			state := DefaultCircuitBreaker.State(accountKey)
-			reason, eventReason, msg := circuitBreakerBlockDetails(accountKey, state, cooldown)
+			reason := ReasonCircuitBreakerOpen
+			eventReason := ReasonCircuitBreakerOpen
+			msg := fmt.Sprintf("Circuit breaker open for account %s; reconciliation paused for %s", accountKey, cooldown)
 
 			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: namespacedName,


### PR DESCRIPTION
This pull request refactors how circuit breaker status is handled in the controllers, centralizing and improving the logic for setting and updating blocked conditions. The main improvement is the introduction of a new helper function, `applyCircuitBreakerBlockedConditions`, which ensures that status conditions and events are only emitted when there is an actual transition into a blocked state or when the resource spec changes while blocked. This reduces unnecessary status updates and event emissions, and ensures the correct handling of observed generations. The changes also add a new test to verify correct behavior when the spec changes during a circuit breaker block.

**Circuit breaker condition handling improvements:**

* Added `applyCircuitBreakerBlockedConditions` and `blockedConditionMatches` helper functions to `circuit_breaker_status.go`, encapsulating the logic for updating status conditions and emitting events only on transitions into a blocked state or when the spec generation changes. This ensures more efficient and correct status management.
* Refactored all controllers (`maintenancewindow_controller.go`, `monitor_controller.go`, `monitorgroup_controller.go`, `slackintegration_controller.go`) to use `applyCircuitBreakerBlockedConditions` instead of duplicating logic for checking and setting blocked conditions. [[1]](diffhunk://#diff-c7d7133c9ee6507beec1c7c4b9ab7e11115e94d5c74cae82422af375c463e644L187-R187) [[2]](diffhunk://#diff-9e023d2e1e20fef8959ffd17dac8fda8c43b701f255956b07185effd0ee0fca1L257-R258) [[3]](diffhunk://#diff-4f854ba1410f6fbba96b5a307cbaf4fd49f460b10141b05286ab5aa21bd0ec13L191-R192) [[4]](diffhunk://#diff-1183d5d9eba6f7979d41af6fcfb56cb960f4b35ac245acd48957d3caacc8be8eL178-R178)

**Test and code cleanup:**

* Updated controller tests to use static expected values for circuit breaker reasons and messages, reflecting the refactored logic. [[1]](diffhunk://#diff-af42bbca1b2103f468051c6cff24f22a44e3af35e66bd6fb573a60234f94e677L180-R182) [[2]](diffhunk://#diff-0516a5866bd75715dfd5c4d8567641b0f423c1fd9f23ae510f3806cc12424102L121-R124) [[3]](diffhunk://#diff-5e7dd3a75dcd4225d101908251511b1661563b26dd272d6e3c2219c45bac9525L311-R313)
* Added a new test to `monitor_controller_test.go` to verify that the `ObservedGeneration` of blocked conditions is refreshed when the spec changes while the circuit breaker is open, and that `LastTransitionTime` is not updated unless the reason or message changes.

**Imports and minor code adjustments:**

* Cleaned up unused imports in affected controller files. [[1]](diffhunk://#diff-c7d7133c9ee6507beec1c7c4b9ab7e11115e94d5c74cae82422af375c463e644L27) [[2]](diffhunk://#diff-0516a5866bd75715dfd5c4d8567641b0f423c1fd9f23ae510f3806cc12424102R21) [[3]](diffhunk://#diff-1183d5d9eba6f7979d41af6fcfb56cb960f4b35ac245acd48957d3caacc8be8eL30)