### PR TITLE
fix(monitorgroup): adopt existing backend group to close non-conflict duplicate-create race

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -31,3 +31,11 @@ flags:
       - internal/
       - api/
     carryforward: true
+
+# Exclude test-only infrastructure that exists solely to be exercised by tests
+# in other packages. Lines here would otherwise inflate patch denominators
+# without measuring production-code coverage.
+ignore:
+  - "internal/uptimerobot/uptimerobottest/"
+  - "**/*_test.go"
+  - "**/zz_generated_*.go"

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -60,6 +60,9 @@ const (
 	// circuit breaker is blocking calls in a non-open state (for example,
 	// half-open while a probe is already in flight).
 	ReasonCircuitBreakerBlocked = "CircuitBreakerBlocked"
+	// ReasonValidationFailed indicates the resource spec failed a controller-side
+	// validation check that should normally be caught by the CRD validating webhook.
+	ReasonValidationFailed = "ValidationFailed"
 )
 
 // SetCondition sets or updates a condition in the conditions list

--- a/internal/controller/monitorgroup_adopt_test.go
+++ b/internal/controller/monitorgroup_adopt_test.go
@@ -28,56 +28,64 @@ func TestFindAdoptableGroup(t *testing.T) {
 		{ID: 3, Name: "beta"},
 		{ID: 9, Name: "beta"},
 		{ID: 7, Name: "gamma"},
+		{ID: 0, Name: "zero"},
 	}
 
 	tests := []struct {
-		name         string
-		friendlyName string
-		groups       []uptimerobot.GroupWireFormat
-		wantID       int
-		wantFound    bool
+		name           string
+		friendlyName   string
+		groups         []uptimerobot.GroupWireFormat
+		wantID         int
+		wantMatchCount int
 	}{
 		{
-			name:         "empty friendly name never matches",
-			friendlyName: "",
-			groups:       groups,
-			wantFound:    false,
+			name:           "empty friendly name never matches",
+			friendlyName:   "",
+			groups:         groups,
+			wantMatchCount: 0,
 		},
 		{
-			name:         "no matching name",
-			friendlyName: "delta",
-			groups:       groups,
-			wantFound:    false,
+			name:           "no matching name",
+			friendlyName:   "delta",
+			groups:         groups,
+			wantMatchCount: 0,
 		},
 		{
-			name:         "single match returns that group",
-			friendlyName: "alpha",
-			groups:       groups,
-			wantID:       5,
-			wantFound:    true,
+			name:           "single match returns that group",
+			friendlyName:   "alpha",
+			groups:         groups,
+			wantID:         5,
+			wantMatchCount: 1,
 		},
 		{
-			name:         "multiple matches return lowest ID for deterministic adoption",
-			friendlyName: "beta",
-			groups:       groups,
-			wantID:       3,
-			wantFound:    true,
+			name:           "multiple matches return lowest ID for deterministic adoption",
+			friendlyName:   "beta",
+			groups:         groups,
+			wantID:         3,
+			wantMatchCount: 2,
 		},
 		{
-			name:         "empty group list does not match",
-			friendlyName: "alpha",
-			groups:       nil,
-			wantFound:    false,
+			name:           "zero-ID group is treated as a real match (no zero-value sentinel collision)",
+			friendlyName:   "zero",
+			groups:         groups,
+			wantID:         0,
+			wantMatchCount: 1,
+		},
+		{
+			name:           "empty group list does not match",
+			friendlyName:   "alpha",
+			groups:         nil,
+			wantMatchCount: 0,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, found := findAdoptableGroup(tc.groups, tc.friendlyName)
-			if found != tc.wantFound {
-				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			got, matchCount := findAdoptableGroup(tc.groups, tc.friendlyName)
+			if matchCount != tc.wantMatchCount {
+				t.Fatalf("matchCount = %d, want %d", matchCount, tc.wantMatchCount)
 			}
-			if found && got.ID != tc.wantID {
+			if matchCount > 0 && got.ID != tc.wantID {
 				t.Fatalf("got ID %d, want %d", got.ID, tc.wantID)
 			}
 		})

--- a/internal/controller/monitorgroup_adopt_test.go
+++ b/internal/controller/monitorgroup_adopt_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/joelp172/uptime-robot-operator/internal/uptimerobot"
+)
+
+func TestFindAdoptableGroup(t *testing.T) {
+	groups := []uptimerobot.GroupWireFormat{
+		{ID: 5, Name: "alpha"},
+		{ID: 3, Name: "beta"},
+		{ID: 9, Name: "beta"},
+		{ID: 7, Name: "gamma"},
+	}
+
+	tests := []struct {
+		name         string
+		friendlyName string
+		groups       []uptimerobot.GroupWireFormat
+		wantID       int
+		wantFound    bool
+	}{
+		{
+			name:         "empty friendly name never matches",
+			friendlyName: "",
+			groups:       groups,
+			wantFound:    false,
+		},
+		{
+			name:         "no matching name",
+			friendlyName: "delta",
+			groups:       groups,
+			wantFound:    false,
+		},
+		{
+			name:         "single match returns that group",
+			friendlyName: "alpha",
+			groups:       groups,
+			wantID:       5,
+			wantFound:    true,
+		},
+		{
+			name:         "multiple matches return lowest ID for deterministic adoption",
+			friendlyName: "beta",
+			groups:       groups,
+			wantID:       3,
+			wantFound:    true,
+		},
+		{
+			name:         "empty group list does not match",
+			friendlyName: "alpha",
+			groups:       nil,
+			wantFound:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := findAdoptableGroup(tc.groups, tc.friendlyName)
+			if found != tc.wantFound {
+				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			}
+			if found && got.ID != tc.wantID {
+				t.Fatalf("got ID %d, want %d", got.ID, tc.wantID)
+			}
+		})
+	}
+}

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -254,7 +254,7 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			if r.Recorder != nil {
 				r.Recorder.Event(groupResource, "Warning", "ValidationFailed", msg)
 			}
-			logger.Error(nil, msg, "monitorgroup", req.NamespacedName)
+			logger.Info(msg, "monitorgroup", req.NamespacedName)
 			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
 				return ctrl.Result{}, fmt.Errorf("status write after validation failure: %w", updateErr)
 			}
@@ -402,41 +402,48 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					}
 				}
 
-				var newID int
-				eventReason := "Recreated"
-				eventMsg := ""
 				if matchCount > 0 {
-					newID = adopted.ID
-					eventReason = "Adopted"
-					eventMsg = fmt.Sprintf("Adopted existing monitor group with ID %d after backend 404", newID)
-				} else {
-					creationPayload := uptimerobot.GroupCreationWireFormat{
-						Name:       groupResource.Spec.FriendlyName,
-						MonitorIDs: aggregatedMonitorIDs,
-						GroupIDs:   groupResource.Spec.PullFromGroups,
+					// Adopting an existing group on the 404 path: we have not yet pushed
+					// the desired Spec to that backend group, so do not claim Synced=true.
+					// Persist the new ID and requeue immediately so the next reconcile
+					// runs the update path against the adopted ID.
+					onAPISuccess(accountKey, r.Recorder, groupResource)
+					groupResource.Status.ID = strconv.Itoa(adopted.ID)
+					if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
+						return ctrl.Result{}, fmt.Errorf("status write after backend adopt-on-404: %w", statusErr)
 					}
-					backendResponse, recreationErr := backendClient.SpawnGroupInBackend(ctx, creationPayload)
-					if recreationErr != nil {
-						metrics.ReconciliationErrorsTotal.WithLabelValues("monitorgroup", "api_error").Inc()
-						groupResource.Status.Ready = false
-						msg := fmt.Sprintf("Group recreation failed: %v", recreationErr)
-						SetReadyCondition(&groupResource.Status.Conditions, false, ReasonAPIError, msg, groupResource.Generation)
-						SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, fmt.Sprintf("Failed to recreate group in UptimeRobot: %v", recreationErr), groupResource.Generation)
-						SetErrorCondition(&groupResource.Status.Conditions, true, ReasonAPIError, msg, groupResource.Generation)
-						if r.Recorder != nil {
-							r.Recorder.Event(groupResource, "Warning", "SyncFailed", msg)
-						}
-						onAPIFailure(accountKey, recreationErr, r.Recorder, groupResource)
-						if statusUpdateErr := r.updateMonitorGroupStatus(ctx, groupResource); statusUpdateErr != nil {
-							return ctrl.Result{}, fmt.Errorf("status write after recreation failure: %w", statusUpdateErr)
-						}
-						return ctrl.Result{}, fmt.Errorf("group recreation failed: %w", recreationErr)
+					if r.Recorder != nil {
+						r.Recorder.Event(groupResource, "Normal", "Adopted",
+							fmt.Sprintf("Adopted existing monitor group with ID %d after backend 404", adopted.ID))
 					}
-					newID = backendResponse.ID
-					eventMsg = fmt.Sprintf("Monitor group recreated with ID %d", newID)
+					return ctrl.Result{Requeue: true}, nil
 				}
 
-				groupResource.Status.ID = strconv.Itoa(newID)
+				creationPayload := uptimerobot.GroupCreationWireFormat{
+					Name:       groupResource.Spec.FriendlyName,
+					MonitorIDs: aggregatedMonitorIDs,
+					GroupIDs:   groupResource.Spec.PullFromGroups,
+				}
+				backendResponse, recreationErr := backendClient.SpawnGroupInBackend(ctx, creationPayload)
+				if recreationErr != nil {
+					metrics.ReconciliationErrorsTotal.WithLabelValues("monitorgroup", "api_error").Inc()
+					groupResource.Status.Ready = false
+					msg := fmt.Sprintf("Group recreation failed: %v", recreationErr)
+					SetReadyCondition(&groupResource.Status.Conditions, false, ReasonAPIError, msg, groupResource.Generation)
+					SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, fmt.Sprintf("Failed to recreate group in UptimeRobot: %v", recreationErr), groupResource.Generation)
+					SetErrorCondition(&groupResource.Status.Conditions, true, ReasonAPIError, msg, groupResource.Generation)
+					if r.Recorder != nil {
+						r.Recorder.Event(groupResource, "Warning", "SyncFailed", msg)
+					}
+					onAPIFailure(accountKey, recreationErr, r.Recorder, groupResource)
+					if statusUpdateErr := r.updateMonitorGroupStatus(ctx, groupResource); statusUpdateErr != nil {
+						return ctrl.Result{}, fmt.Errorf("status write after recreation failure: %w", statusUpdateErr)
+					}
+					return ctrl.Result{}, fmt.Errorf("group recreation failed: %w", recreationErr)
+				}
+
+				// Recreate posted the desired Spec, so Synced=true is honest here.
+				groupResource.Status.ID = strconv.Itoa(backendResponse.ID)
 				groupResource.Status.Ready = true
 				groupResource.Status.MonitorCount = len(aggregatedMonitorIDs)
 				nowTimestamp := metav1.Now()
@@ -448,10 +455,11 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				// Same ordering as the create path: success signal, then status, then event.
 				onAPISuccess(accountKey, r.Recorder, groupResource)
 				if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-					return ctrl.Result{}, fmt.Errorf("status write after backend recreate/adopt: %w", statusErr)
+					return ctrl.Result{}, fmt.Errorf("status write after backend recreate: %w", statusErr)
 				}
 				if r.Recorder != nil {
-					r.Recorder.Event(groupResource, "Normal", eventReason, eventMsg)
+					r.Recorder.Event(groupResource, "Normal", "Recreated",
+						fmt.Sprintf("Monitor group recreated with ID %d", backendResponse.ID))
 				}
 				return ctrl.Result{RequeueAfter: AddSyncJitter(groupResource.Spec.SyncInterval.Duration)}, nil
 			}

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -242,7 +242,43 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Step 7: Execute creation or update logic
 	if groupResource.Status.ID == "" {
-		// Creation pathway
+		// Adopt an existing backend group with the same FriendlyName before creating, so a
+		// previous reconcile that successfully created the group but failed to persist
+		// Status.ID (non-conflict status-write failure, pod restart, network blip) does not
+		// produce a duplicate.
+		existingGroups, listErr := backendClient.EnumerateGroupsFromBackend(ctx)
+		if listErr != nil {
+			metrics.ReconciliationErrorsTotal.WithLabelValues("monitorgroup", "api_error").Inc()
+			groupResource.Status.Ready = false
+			msg := fmt.Sprintf("Group adoption lookup failed: %v", listErr)
+			SetReadyCondition(&groupResource.Status.Conditions, false, ReasonAPIError, msg, groupResource.Generation)
+			SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, msg, groupResource.Generation)
+			SetErrorCondition(&groupResource.Status.Conditions, true, ReasonAPIError, msg, groupResource.Generation)
+			if r.Recorder != nil {
+				r.Recorder.Event(groupResource, "Warning", "SyncFailed", msg)
+			}
+			onAPIFailure(accountKey, listErr, r.Recorder, groupResource)
+			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			return ctrl.Result{}, fmt.Errorf("group adoption lookup failed: %w", listErr)
+		}
+
+		if adopted, found := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName); found {
+			groupResource.Status.ID = strconv.Itoa(adopted.ID)
+			logger.Info("Adopting existing backend group with matching FriendlyName",
+				"name", groupResource.Spec.FriendlyName, "id", groupResource.Status.ID)
+			if r.Recorder != nil {
+				r.Recorder.Event(groupResource, "Normal", "Adopted",
+					fmt.Sprintf("Adopted existing monitor group with ID %s", groupResource.Status.ID))
+			}
+			if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			// Requeue so the next reconcile runs the update path with the adopted ID.
+			return ctrl.Result{Requeue: true}, nil
+		}
+
 		creationPayload := uptimerobot.GroupCreationWireFormat{
 			Name:       groupResource.Spec.FriendlyName,
 			MonitorIDs: aggregatedMonitorIDs,
@@ -276,14 +312,18 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		SetSyncedCondition(&groupResource.Status.Conditions, true, ReasonSyncSuccess, "Successfully synced with UptimeRobot", groupResource.Generation)
 		SetErrorCondition(&groupResource.Status.Conditions, false, ReasonReconcileSuccess, "", groupResource.Generation)
 
+		// Persist Status.ID before recording the event so a failed status write does not
+		// produce a misleading "Created" event for a backend group that the next reconcile
+		// will adopt rather than recreate.
+		if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
+			return ctrl.Result{}, statusErr
+		}
+
 		if r.Recorder != nil {
 			r.Recorder.Event(groupResource, "Normal", "Created", fmt.Sprintf("Monitor group created with ID %s", groupResource.Status.ID))
 		}
 
 		onAPISuccess(accountKey, r.Recorder, groupResource)
-		if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-			return ctrl.Result{}, statusErr
-		}
 	} else {
 		// Update pathway
 		updatePayload := uptimerobot.GroupUpdateWireFormat{
@@ -373,6 +413,29 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	return ctrl.Result{RequeueAfter: AddSyncJitter(groupResource.Spec.SyncInterval.Duration)}, nil
+}
+
+// findAdoptableGroup returns the lowest-ID backend group whose Name matches friendlyName,
+// so a CR whose previous create succeeded in the backend but whose Status.ID was never
+// persisted can adopt the existing group instead of creating a duplicate. The lowest ID
+// is preferred so adoption is deterministic and clusters that already accumulated
+// duplicates from this bug converge on the oldest group.
+func findAdoptableGroup(groups []uptimerobot.GroupWireFormat, friendlyName string) (uptimerobot.GroupWireFormat, bool) {
+	if friendlyName == "" {
+		return uptimerobot.GroupWireFormat{}, false
+	}
+	var match uptimerobot.GroupWireFormat
+	found := false
+	for _, g := range groups {
+		if g.Name != friendlyName {
+			continue
+		}
+		if !found || g.ID < match.ID {
+			match = g
+			found = true
+		}
+	}
+	return match, found
 }
 
 // updateMonitorGroupStatus writes status and retries on conflict by refetching

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -242,6 +242,25 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Step 7: Execute creation or update logic
 	if groupResource.Status.ID == "" {
+		// Treat an empty FriendlyName as a terminal spec error rather than calling
+		// the backend with name="". The CRD validating webhook should already make
+		// this unreachable, so we just surface it loudly instead of attempting any
+		// API work.
+		if groupResource.Spec.FriendlyName == "" {
+			groupResource.Status.Ready = false
+			msg := "MonitorGroup spec.friendlyName must not be empty"
+			SetReadyCondition(&groupResource.Status.Conditions, false, ReasonValidationFailed, msg, groupResource.Generation)
+			SetErrorCondition(&groupResource.Status.Conditions, true, ReasonValidationFailed, msg, groupResource.Generation)
+			if r.Recorder != nil {
+				r.Recorder.Event(groupResource, "Warning", "ValidationFailed", msg)
+			}
+			logger.Error(nil, msg, "monitorgroup", req.NamespacedName)
+			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
+				return ctrl.Result{}, fmt.Errorf("status write after validation failure: %w", updateErr)
+			}
+			return ctrl.Result{}, nil
+		}
+
 		// Adopt an existing backend group with the same FriendlyName before creating: a
 		// previous reconcile may have created the group but lost the Status.ID write
 		// (non-conflict status-write failure, pod restart, network blip). Without
@@ -265,17 +284,6 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, fmt.Errorf("group adoption lookup failed: %w", listErr)
 		}
 
-		// Release the circuit-breaker probe slot before any status write so a HalfOpen
-		// probe is not left in flight if the status update below fails.
-		onAPISuccess(accountKey, r.Recorder, groupResource)
-
-		if groupResource.Spec.FriendlyName == "" {
-			// Should be unreachable: the CRD validating webhook enforces a non-empty
-			// FriendlyName. Surface loudly rather than silently posting a nameless group.
-			logger.Error(nil, "MonitorGroup reached create branch with empty FriendlyName; skipping adoption lookup",
-				"monitorgroup", req.NamespacedName)
-		}
-
 		adopted, matchCount := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName)
 		if matchCount > 1 {
 			logger.Info("Multiple backend groups share this FriendlyName; adopting lowest ID",
@@ -286,6 +294,11 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 		}
 		if matchCount > 0 {
+			// Adoption: the list call is the only backend call in this branch, so this
+			// is the last API call and the right place to release the circuit-breaker
+			// probe slot. Done before the status write so a HalfOpen probe is freed
+			// even if K8s rejects the update.
+			onAPISuccess(accountKey, r.Recorder, groupResource)
 			groupResource.Status.ID = strconv.Itoa(adopted.ID)
 			logger.Info("Adopting existing backend group with matching FriendlyName",
 				"name", groupResource.Spec.FriendlyName, "id", groupResource.Status.ID)
@@ -378,7 +391,6 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					}
 					return ctrl.Result{}, fmt.Errorf("group adoption lookup failed: %w", listErr)
 				}
-				onAPISuccess(accountKey, r.Recorder, groupResource)
 
 				adopted, matchCount := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName)
 				if matchCount > 1 {

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -264,16 +264,21 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, fmt.Errorf("group adoption lookup failed: %w", listErr)
 		}
 
+		// Record API success for the list call now so the circuit breaker probe slot is
+		// released even if the status write below fails — otherwise a HalfOpen probe stays
+		// in-flight and blocks subsequent calls for this account.
+		onAPISuccess(accountKey, r.Recorder, groupResource)
+
 		if adopted, found := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName); found {
 			groupResource.Status.ID = strconv.Itoa(adopted.ID)
 			logger.Info("Adopting existing backend group with matching FriendlyName",
 				"name", groupResource.Spec.FriendlyName, "id", groupResource.Status.ID)
+			if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
 			if r.Recorder != nil {
 				r.Recorder.Event(groupResource, "Normal", "Adopted",
 					fmt.Sprintf("Adopted existing monitor group with ID %s", groupResource.Status.ID))
-			}
-			if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-				return ctrl.Result{}, statusErr
 			}
 			// Requeue so the next reconcile runs the update path with the adopted ID.
 			return ctrl.Result{Requeue: true}, nil
@@ -312,6 +317,11 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		SetSyncedCondition(&groupResource.Status.Conditions, true, ReasonSyncSuccess, "Successfully synced with UptimeRobot", groupResource.Generation)
 		SetErrorCondition(&groupResource.Status.Conditions, false, ReasonReconcileSuccess, "", groupResource.Generation)
 
+		// Record API success before the status write so the circuit breaker probe slot is
+		// released even if the K8s status write fails — otherwise a HalfOpen probe stays
+		// in-flight and blocks subsequent calls for this account.
+		onAPISuccess(accountKey, r.Recorder, groupResource)
+
 		// Persist Status.ID before recording the event so a failed status write does not
 		// produce a misleading "Created" event for a backend group that the next reconcile
 		// will adopt rather than recreate.
@@ -322,8 +332,6 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if r.Recorder != nil {
 			r.Recorder.Event(groupResource, "Normal", "Created", fmt.Sprintf("Monitor group created with ID %s", groupResource.Status.ID))
 		}
-
-		onAPISuccess(accountKey, r.Recorder, groupResource)
 	} else {
 		// Update pathway
 		updatePayload := uptimerobot.GroupUpdateWireFormat{

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -183,6 +183,26 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	backendClient := uptimerobot.NewClient(apiToken)
 	accountKey := credentialVault.Name
 
+	// Spec validation: run before the circuit breaker so a no-API-call short-circuit
+	// does not take a HalfOpen probe slot. Empty FriendlyName is unreachable through
+	// the typed CRD API (MinLength=1) but kept as defense-in-depth in case validation
+	// is ever bypassed.
+	if groupResource.Status.ID == "" && groupResource.Spec.FriendlyName == "" {
+		groupResource.Status.Ready = false
+		msg := "MonitorGroup spec.friendlyName must not be empty"
+		SetReadyCondition(&groupResource.Status.Conditions, false, ReasonValidationFailed, msg, groupResource.Generation)
+		SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonValidationFailed, msg, groupResource.Generation)
+		SetErrorCondition(&groupResource.Status.Conditions, true, ReasonValidationFailed, msg, groupResource.Generation)
+		if r.Recorder != nil {
+			r.Recorder.Event(groupResource, "Warning", "ValidationFailed", msg)
+		}
+		logger.Info(msg, "monitorgroup", req.NamespacedName)
+		if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
+			return ctrl.Result{}, fmt.Errorf("status write after validation failure: %w", updateErr)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	// Circuit breaker: skip API calls when the circuit is not allowing traffic.
 	if !DefaultCircuitBreaker.Allow(accountKey) {
 		state := DefaultCircuitBreaker.State(accountKey)
@@ -242,25 +262,6 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Step 7: Execute creation or update logic
 	if groupResource.Status.ID == "" {
-		// Treat an empty FriendlyName as a terminal spec error rather than calling
-		// the backend with name="". The CRD validating webhook should already make
-		// this unreachable, so we just surface it loudly instead of attempting any
-		// API work.
-		if groupResource.Spec.FriendlyName == "" {
-			groupResource.Status.Ready = false
-			msg := "MonitorGroup spec.friendlyName must not be empty"
-			SetReadyCondition(&groupResource.Status.Conditions, false, ReasonValidationFailed, msg, groupResource.Generation)
-			SetErrorCondition(&groupResource.Status.Conditions, true, ReasonValidationFailed, msg, groupResource.Generation)
-			if r.Recorder != nil {
-				r.Recorder.Event(groupResource, "Warning", "ValidationFailed", msg)
-			}
-			logger.Info(msg, "monitorgroup", req.NamespacedName)
-			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
-				return ctrl.Result{}, fmt.Errorf("status write after validation failure: %w", updateErr)
-			}
-			return ctrl.Result{}, nil
-		}
-
 		// Adopt an existing backend group with the same FriendlyName before creating: a
 		// previous reconcile may have created the group but lost the Status.ID write
 		// (non-conflict status-write failure, pod restart, network blip). Without
@@ -297,9 +298,16 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// Adoption: the list call is the only backend call in this branch, so this
 			// is the last API call and the right place to release the circuit-breaker
 			// probe slot. Done before the status write so a HalfOpen probe is freed
-			// even if K8s rejects the update.
+			// even if K8s rejects the update. Conditions explicitly mark Synced=false
+			// because we have not yet pushed the desired Spec to the adopted group;
+			// the immediate requeue runs the update path next reconcile.
 			onAPISuccess(accountKey, r.Recorder, groupResource)
 			groupResource.Status.ID = strconv.Itoa(adopted.ID)
+			groupResource.Status.Ready = false
+			adoptMsg := fmt.Sprintf("Adopted existing monitor group with ID %s; pending sync", groupResource.Status.ID)
+			SetReadyCondition(&groupResource.Status.Conditions, false, ReasonReconcileDegraded, adoptMsg, groupResource.Generation)
+			SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncSkipped, "Adopted backend group; spec not yet applied", groupResource.Generation)
+			SetErrorCondition(&groupResource.Status.Conditions, false, ReasonReconcileDegraded, "", groupResource.Generation)
 			logger.Info("Adopting existing backend group with matching FriendlyName",
 				"name", groupResource.Spec.FriendlyName, "id", groupResource.Status.ID)
 			if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
@@ -405,10 +413,17 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				if matchCount > 0 {
 					// Adopting an existing group on the 404 path: we have not yet pushed
 					// the desired Spec to that backend group, so do not claim Synced=true.
-					// Persist the new ID and requeue immediately so the next reconcile
-					// runs the update path against the adopted ID.
+					// Reset the conditions so a stale Synced=true from a previous
+					// reconcile doesn't misreport the resource as in-sync, persist the
+					// new ID, and requeue immediately so the next reconcile runs the
+					// update path against the adopted ID.
 					onAPISuccess(accountKey, r.Recorder, groupResource)
 					groupResource.Status.ID = strconv.Itoa(adopted.ID)
+					groupResource.Status.Ready = false
+					adoptMsg := fmt.Sprintf("Adopted existing monitor group with ID %d after backend 404; pending sync", adopted.ID)
+					SetReadyCondition(&groupResource.Status.Conditions, false, ReasonReconcileDegraded, adoptMsg, groupResource.Generation)
+					SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncSkipped, "Adopted backend group; spec not yet applied", groupResource.Generation)
+					SetErrorCondition(&groupResource.Status.Conditions, false, ReasonReconcileDegraded, "", groupResource.Generation)
 					if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
 						return ctrl.Result{}, fmt.Errorf("status write after backend adopt-on-404: %w", statusErr)
 					}

--- a/internal/controller/monitorgroup_controller.go
+++ b/internal/controller/monitorgroup_controller.go
@@ -242,10 +242,11 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Step 7: Execute creation or update logic
 	if groupResource.Status.ID == "" {
-		// Adopt an existing backend group with the same FriendlyName before creating, so a
-		// previous reconcile that successfully created the group but failed to persist
-		// Status.ID (non-conflict status-write failure, pod restart, network blip) does not
-		// produce a duplicate.
+		// Adopt an existing backend group with the same FriendlyName before creating: a
+		// previous reconcile may have created the group but lost the Status.ID write
+		// (non-conflict status-write failure, pod restart, network blip). Without
+		// adoption the next reconcile sees Status.ID == "" and posts a duplicate, which
+		// UptimeRobot accepts because POST /monitor-groups does not 409 on name reuse.
 		existingGroups, listErr := backendClient.EnumerateGroupsFromBackend(ctx)
 		if listErr != nil {
 			metrics.ReconciliationErrorsTotal.WithLabelValues("monitorgroup", "api_error").Inc()
@@ -255,26 +256,41 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, msg, groupResource.Generation)
 			SetErrorCondition(&groupResource.Status.Conditions, true, ReasonAPIError, msg, groupResource.Generation)
 			if r.Recorder != nil {
-				r.Recorder.Event(groupResource, "Warning", "SyncFailed", msg)
+				r.Recorder.Event(groupResource, "Warning", "AdoptionLookupFailed", msg)
 			}
 			onAPIFailure(accountKey, listErr, r.Recorder, groupResource)
 			if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
-				return ctrl.Result{}, updateErr
+				return ctrl.Result{}, fmt.Errorf("status write after adoption lookup failure: %w", updateErr)
 			}
 			return ctrl.Result{}, fmt.Errorf("group adoption lookup failed: %w", listErr)
 		}
 
-		// Record API success for the list call now so the circuit breaker probe slot is
-		// released even if the status write below fails — otherwise a HalfOpen probe stays
-		// in-flight and blocks subsequent calls for this account.
+		// Release the circuit-breaker probe slot before any status write so a HalfOpen
+		// probe is not left in flight if the status update below fails.
 		onAPISuccess(accountKey, r.Recorder, groupResource)
 
-		if adopted, found := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName); found {
+		if groupResource.Spec.FriendlyName == "" {
+			// Should be unreachable: the CRD validating webhook enforces a non-empty
+			// FriendlyName. Surface loudly rather than silently posting a nameless group.
+			logger.Error(nil, "MonitorGroup reached create branch with empty FriendlyName; skipping adoption lookup",
+				"monitorgroup", req.NamespacedName)
+		}
+
+		adopted, matchCount := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName)
+		if matchCount > 1 {
+			logger.Info("Multiple backend groups share this FriendlyName; adopting lowest ID",
+				"name", groupResource.Spec.FriendlyName, "matchCount", matchCount, "adoptedID", adopted.ID)
+			if r.Recorder != nil {
+				r.Recorder.Event(groupResource, "Warning", "AdoptionNameCollision",
+					fmt.Sprintf("%d backend groups named %q exist; adopting lowest ID %d", matchCount, groupResource.Spec.FriendlyName, adopted.ID))
+			}
+		}
+		if matchCount > 0 {
 			groupResource.Status.ID = strconv.Itoa(adopted.ID)
 			logger.Info("Adopting existing backend group with matching FriendlyName",
 				"name", groupResource.Spec.FriendlyName, "id", groupResource.Status.ID)
 			if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-				return ctrl.Result{}, statusErr
+				return ctrl.Result{}, fmt.Errorf("status write after adoption: %w", statusErr)
 			}
 			if r.Recorder != nil {
 				r.Recorder.Event(groupResource, "Normal", "Adopted",
@@ -317,18 +333,15 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		SetSyncedCondition(&groupResource.Status.Conditions, true, ReasonSyncSuccess, "Successfully synced with UptimeRobot", groupResource.Generation)
 		SetErrorCondition(&groupResource.Status.Conditions, false, ReasonReconcileSuccess, "", groupResource.Generation)
 
-		// Record API success before the status write so the circuit breaker probe slot is
-		// released even if the K8s status write fails — otherwise a HalfOpen probe stays
-		// in-flight and blocks subsequent calls for this account.
+		// Order matters: release the circuit-breaker probe before the status write (so a
+		// HalfOpen probe is freed even if K8s rejects the update), then persist Status.ID,
+		// then emit the Created event last so a failed status write does not surface a
+		// misleading event for a backend group the next reconcile will adopt rather than
+		// recreate.
 		onAPISuccess(accountKey, r.Recorder, groupResource)
-
-		// Persist Status.ID before recording the event so a failed status write does not
-		// produce a misleading "Created" event for a backend group that the next reconcile
-		// will adopt rather than recreate.
 		if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-			return ctrl.Result{}, statusErr
+			return ctrl.Result{}, fmt.Errorf("status write after backend create: %w", statusErr)
 		}
-
 		if r.Recorder != nil {
 			r.Recorder.Event(groupResource, "Normal", "Created", fmt.Sprintf("Monitor group created with ID %s", groupResource.Status.ID))
 		}
@@ -344,33 +357,75 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if updateErr != nil {
 			// Handle out-of-band deletion
 			if uptimerobot.IsNotFound(updateErr) {
-				logger.Info("Group missing from backend, recreating", "id", groupResource.Status.ID)
+				logger.Info("Group missing from backend, attempting adoption before recreate", "id", groupResource.Status.ID)
 
-				creationPayload := uptimerobot.GroupCreationWireFormat{
-					Name:       groupResource.Spec.FriendlyName,
-					MonitorIDs: aggregatedMonitorIDs,
-					GroupIDs:   groupResource.Spec.PullFromGroups,
-				}
-
-				backendResponse, recreationErr := backendClient.SpawnGroupInBackend(ctx, creationPayload)
-				if recreationErr != nil {
+				// List existing groups before recreating so we don't re-introduce the
+				// duplicate-create race when an earlier reconcile created the new group
+				// but lost the Status.ID write.
+				existingGroups, listErr := backendClient.EnumerateGroupsFromBackend(ctx)
+				if listErr != nil {
 					metrics.ReconciliationErrorsTotal.WithLabelValues("monitorgroup", "api_error").Inc()
-					groupResource.Status.Ready = false
-					msg := fmt.Sprintf("Group recreation failed: %v", recreationErr)
+					msg := fmt.Sprintf("Group adoption lookup failed: %v", listErr)
 					SetReadyCondition(&groupResource.Status.Conditions, false, ReasonAPIError, msg, groupResource.Generation)
-					SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, fmt.Sprintf("Failed to recreate group in UptimeRobot: %v", recreationErr), groupResource.Generation)
+					SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, msg, groupResource.Generation)
 					SetErrorCondition(&groupResource.Status.Conditions, true, ReasonAPIError, msg, groupResource.Generation)
 					if r.Recorder != nil {
-						r.Recorder.Event(groupResource, "Warning", "SyncFailed", msg)
+						r.Recorder.Event(groupResource, "Warning", "AdoptionLookupFailed", msg)
 					}
-					onAPIFailure(accountKey, recreationErr, r.Recorder, groupResource)
-					if updateErr := r.updateMonitorGroupStatus(ctx, groupResource); updateErr != nil {
-						return ctrl.Result{}, updateErr
+					onAPIFailure(accountKey, listErr, r.Recorder, groupResource)
+					if statusUpdateErr := r.updateMonitorGroupStatus(ctx, groupResource); statusUpdateErr != nil {
+						return ctrl.Result{}, fmt.Errorf("status write after adoption lookup failure: %w", statusUpdateErr)
 					}
-					return ctrl.Result{}, fmt.Errorf("group recreation failed: %w", recreationErr)
+					return ctrl.Result{}, fmt.Errorf("group adoption lookup failed: %w", listErr)
+				}
+				onAPISuccess(accountKey, r.Recorder, groupResource)
+
+				adopted, matchCount := findAdoptableGroup(existingGroups, groupResource.Spec.FriendlyName)
+				if matchCount > 1 {
+					logger.Info("Multiple backend groups share this FriendlyName; adopting lowest ID",
+						"name", groupResource.Spec.FriendlyName, "matchCount", matchCount, "adoptedID", adopted.ID)
+					if r.Recorder != nil {
+						r.Recorder.Event(groupResource, "Warning", "AdoptionNameCollision",
+							fmt.Sprintf("%d backend groups named %q exist; adopting lowest ID %d", matchCount, groupResource.Spec.FriendlyName, adopted.ID))
+					}
 				}
 
-				groupResource.Status.ID = strconv.Itoa(backendResponse.ID)
+				var newID int
+				eventReason := "Recreated"
+				eventMsg := ""
+				if matchCount > 0 {
+					newID = adopted.ID
+					eventReason = "Adopted"
+					eventMsg = fmt.Sprintf("Adopted existing monitor group with ID %d after backend 404", newID)
+				} else {
+					creationPayload := uptimerobot.GroupCreationWireFormat{
+						Name:       groupResource.Spec.FriendlyName,
+						MonitorIDs: aggregatedMonitorIDs,
+						GroupIDs:   groupResource.Spec.PullFromGroups,
+					}
+					backendResponse, recreationErr := backendClient.SpawnGroupInBackend(ctx, creationPayload)
+					if recreationErr != nil {
+						metrics.ReconciliationErrorsTotal.WithLabelValues("monitorgroup", "api_error").Inc()
+						groupResource.Status.Ready = false
+						msg := fmt.Sprintf("Group recreation failed: %v", recreationErr)
+						SetReadyCondition(&groupResource.Status.Conditions, false, ReasonAPIError, msg, groupResource.Generation)
+						SetSyncedCondition(&groupResource.Status.Conditions, false, ReasonSyncError, fmt.Sprintf("Failed to recreate group in UptimeRobot: %v", recreationErr), groupResource.Generation)
+						SetErrorCondition(&groupResource.Status.Conditions, true, ReasonAPIError, msg, groupResource.Generation)
+						if r.Recorder != nil {
+							r.Recorder.Event(groupResource, "Warning", "SyncFailed", msg)
+						}
+						onAPIFailure(accountKey, recreationErr, r.Recorder, groupResource)
+						if statusUpdateErr := r.updateMonitorGroupStatus(ctx, groupResource); statusUpdateErr != nil {
+							return ctrl.Result{}, fmt.Errorf("status write after recreation failure: %w", statusUpdateErr)
+						}
+						return ctrl.Result{}, fmt.Errorf("group recreation failed: %w", recreationErr)
+					}
+					newID = backendResponse.ID
+					eventMsg = fmt.Sprintf("Monitor group recreated with ID %d", newID)
+				}
+
+				groupResource.Status.ID = strconv.Itoa(newID)
+				groupResource.Status.Ready = true
 				groupResource.Status.MonitorCount = len(aggregatedMonitorIDs)
 				nowTimestamp := metav1.Now()
 				groupResource.Status.LastReconciled = &nowTimestamp
@@ -378,13 +433,13 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				SetSyncedCondition(&groupResource.Status.Conditions, true, ReasonSyncSuccess, "Successfully synced with UptimeRobot", groupResource.Generation)
 				SetErrorCondition(&groupResource.Status.Conditions, false, ReasonReconcileSuccess, "", groupResource.Generation)
 
-				if r.Recorder != nil {
-					r.Recorder.Event(groupResource, "Normal", "Recreated", fmt.Sprintf("Monitor group recreated with ID %s", groupResource.Status.ID))
-				}
-
+				// Same ordering as the create path: success signal, then status, then event.
 				onAPISuccess(accountKey, r.Recorder, groupResource)
 				if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-					return ctrl.Result{}, statusErr
+					return ctrl.Result{}, fmt.Errorf("status write after backend recreate/adopt: %w", statusErr)
+				}
+				if r.Recorder != nil {
+					r.Recorder.Event(groupResource, "Normal", eventReason, eventMsg)
 				}
 				return ctrl.Result{RequeueAfter: AddSyncJitter(groupResource.Spec.SyncInterval.Duration)}, nil
 			}
@@ -398,7 +453,7 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			onAPIFailure(accountKey, updateErr, r.Recorder, groupResource)
 			if statusUpdateErr := r.updateMonitorGroupStatus(ctx, groupResource); statusUpdateErr != nil {
-				return ctrl.Result{}, statusUpdateErr
+				return ctrl.Result{}, fmt.Errorf("status write after backend update failure: %w", statusUpdateErr)
 			}
 			return ctrl.Result{}, fmt.Errorf("group update failed: %w", updateErr)
 		}
@@ -416,34 +471,30 @@ func (r *MonitorGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		onAPISuccess(accountKey, r.Recorder, groupResource)
 		if statusErr := r.updateMonitorGroupStatus(ctx, groupResource); statusErr != nil {
-			return ctrl.Result{}, statusErr
+			return ctrl.Result{}, fmt.Errorf("status write after backend update: %w", statusErr)
 		}
 	}
 
 	return ctrl.Result{RequeueAfter: AddSyncJitter(groupResource.Spec.SyncInterval.Duration)}, nil
 }
 
-// findAdoptableGroup returns the lowest-ID backend group whose Name matches friendlyName,
-// so a CR whose previous create succeeded in the backend but whose Status.ID was never
-// persisted can adopt the existing group instead of creating a duplicate. The lowest ID
-// is preferred so adoption is deterministic and clusters that already accumulated
-// duplicates from this bug converge on the oldest group.
-func findAdoptableGroup(groups []uptimerobot.GroupWireFormat, friendlyName string) (uptimerobot.GroupWireFormat, bool) {
+// findAdoptableGroup returns the lowest-ID backend group matching friendlyName along
+// with the total match count. Lowest-ID wins so adoption is deterministic. matchCount
+// > 1 signals a FriendlyName collision the caller should log.
+func findAdoptableGroup(groups []uptimerobot.GroupWireFormat, friendlyName string) (group uptimerobot.GroupWireFormat, matchCount int) {
 	if friendlyName == "" {
-		return uptimerobot.GroupWireFormat{}, false
+		return uptimerobot.GroupWireFormat{}, 0
 	}
-	var match uptimerobot.GroupWireFormat
-	found := false
 	for _, g := range groups {
 		if g.Name != friendlyName {
 			continue
 		}
-		if !found || g.ID < match.ID {
-			match = g
-			found = true
+		matchCount++
+		if matchCount == 1 || g.ID < group.ID {
+			group = g
 		}
 	}
-	return match, found
+	return group, matchCount
 }
 
 // updateMonitorGroupStatus writes status and retries on conflict by refetching

--- a/internal/controller/monitorgroup_controller_test.go
+++ b/internal/controller/monitorgroup_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -287,18 +288,17 @@ var _ = Describe("MonitorGroup Controller", func() {
 		})
 
 		It("should adopt an existing backend group with matching FriendlyName instead of creating a duplicate", func() {
-			// Simulates a previous reconcile that successfully created the backend group
-			// but lost the Status.ID write (non-conflict failure, pod restart, etc.). The
-			// CR sees Status.ID == "" but a backend group with the same FriendlyName
+			// Simulates a previous reconcile that created the backend group but lost the
+			// Status.ID write — the CR sees Status.ID == "" but a matching backend group
 			// already exists and must be adopted rather than recreated.
-			//
-			// The fake UR backend's GET /monitor-groups fixture lists a group named
-			// "Test Monitor Group" with ID 12345. Using that FriendlyName here makes the
-			// list-and-adopt path observable.
+			DeferCleanup(serverState.Reset)
+
 			mg := CreateMonitorGroup(ctx, "test-adopt-existing-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
 				FriendlyName: "Test Monitor Group",
 			})
 			defer CleanupMonitorGroup(ctx, mg)
+
+			beforeCreates := serverState.MonitorGroupCreateCount()
 
 			recorder := record.NewFakeRecorder(100)
 			reconciler := &MonitorGroupReconciler{
@@ -315,6 +315,7 @@ var _ = Describe("MonitorGroup Controller", func() {
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
 			Expect(mg.Status.ID).To(Equal("12345"))
+			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates), "adoption must not POST a duplicate group")
 
 			close(recorder.Events)
 			sawAdopted := false
@@ -325,6 +326,139 @@ var _ = Describe("MonitorGroup Controller", func() {
 				}
 			}
 			Expect(sawAdopted).To(BeTrue(), "expected an Adopted event recording the adopted backend group ID")
+		})
+
+		It("should not duplicate the backend group when a previous reconcile lost the Status.ID write", func() {
+			// End-to-end recovery: reconcile #1 POSTs a fresh group; we then forcibly
+			// clear Status.ID to simulate a status-write failure that left the backend
+			// orphan in place; reconcile #2 must adopt rather than create a second.
+			DeferCleanup(serverState.Reset)
+
+			mg := CreateMonitorGroup(ctx, "test-recover-lost-status-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Lost Status Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			beforeCreates := serverState.MonitorGroupCreateCount()
+			_, err := ReconcileMonitorGroup(ctx, mg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates + 1))
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			firstID := mg.Status.ID
+			Expect(firstID).NotTo(BeEmpty())
+
+			// Simulate the lost status write from the production failure mode.
+			mg.Status.ID = ""
+			mg.Status.Ready = false
+			Expect(k8sClient.Status().Update(ctx, mg)).To(Succeed())
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates+1), "second reconcile must adopt, not create a duplicate")
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).To(Equal(firstID))
+		})
+
+		It("should surface AdoptionLookupFailed when the backend list call fails", func() {
+			DeferCleanup(serverState.Reset)
+			serverState.SetMonitorGroupsListHTTPStatus(http.StatusInternalServerError)
+
+			mg := CreateMonitorGroup(ctx, "test-adopt-list-fail-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Adopt List Fail Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).To(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			ready := findCondition(mg.Status.Conditions, TypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(ReasonAPIError))
+
+			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(ContainSubstring("AdoptionLookupFailed")))
+		})
+
+		It("should adopt across paginated list responses so matches on later pages are not missed", func() {
+			DeferCleanup(serverState.Reset)
+			serverState.SetMonitorGroups([]map[string]any{
+				{"id": 1001, "name": "Page One Group"},
+				{"id": 1002, "name": "Page One Other"},
+				{"id": 1003, "name": "Paginated Adopt Target"},
+				{"id": 1004, "name": "Page Two Other"},
+			})
+			serverState.SetMonitorGroupListPageSize(2) // forces target onto page 2
+
+			mg := CreateMonitorGroup(ctx, "test-adopt-paginated-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Paginated Adopt Target",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			beforeCreates := serverState.MonitorGroupCreateCount()
+			_, err := ReconcileMonitorGroup(ctx, mg)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).To(Equal("1003"))
+			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates), "adoption across pages must not POST a duplicate")
+		})
+
+		It("should warn and adopt the lowest ID when multiple backend groups share the FriendlyName", func() {
+			DeferCleanup(serverState.Reset)
+			serverState.SetMonitorGroups([]map[string]any{
+				{"id": 5005, "name": "Collision Group"},
+				{"id": 5001, "name": "Collision Group"},
+				{"id": 5003, "name": "Collision Group"},
+			})
+
+			mg := CreateMonitorGroup(ctx, "test-adopt-collision-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Collision Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).To(Equal("5001"))
+
+			close(recorder.Events)
+			sawCollision := false
+			for event := range recorder.Events {
+				if strings.Contains(event, "AdoptionNameCollision") {
+					sawCollision = true
+				}
+			}
+			Expect(sawCollision).To(BeTrue(), "expected an AdoptionNameCollision warning event")
 		})
 
 		It("should surface non-conflict status update errors", func() {

--- a/internal/controller/monitorgroup_controller_test.go
+++ b/internal/controller/monitorgroup_controller_test.go
@@ -424,6 +424,126 @@ var _ = Describe("MonitorGroup Controller", func() {
 			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates), "adoption across pages must not POST a duplicate")
 		})
 
+		It("should adopt instead of recreating when backend returns 404 on update and a matching group exists", func() {
+			// Update path: Status.ID is set, but the backend has lost the group (returns
+			// 404 on PATCH). A previous reconcile may have already recreated and lost the
+			// new ID — the controller must adopt the existing group rather than POST a
+			// duplicate.
+			DeferCleanup(serverState.Reset)
+			serverState.SetMonitorGroups([]map[string]any{
+				{"id": 8001, "name": "Recreate Adopt Group"},
+			})
+			serverState.SetMutateMonitorGroupHTTPStatus(http.StatusNotFound)
+
+			mg := CreateMonitorGroup(ctx, "test-recreate-adopt-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Recreate Adopt Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			// Seed a stale Status.ID so the reconciler enters the update path.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			mg.Status.ID = "9999"
+			mg.Status.Ready = true
+			Expect(k8sClient.Status().Update(ctx, mg)).To(Succeed())
+
+			beforeCreates := serverState.MonitorGroupCreateCount()
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates), "404-on-update must adopt rather than POST a duplicate")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).To(Equal("8001"))
+
+			close(recorder.Events)
+			sawAdopted := false
+			for event := range recorder.Events {
+				if strings.Contains(event, "Adopted") {
+					sawAdopted = true
+				}
+			}
+			Expect(sawAdopted).To(BeTrue(), "expected an Adopted event after recreate-via-adoption")
+		})
+
+		It("should recreate when backend returns 404 on update and no matching group exists", func() {
+			DeferCleanup(serverState.Reset)
+			// Empty backend: no name match available, so the recreate path must POST.
+			serverState.SetMonitorGroups([]map[string]any{})
+			serverState.SetMutateMonitorGroupHTTPStatus(http.StatusNotFound)
+
+			mg := CreateMonitorGroup(ctx, "test-recreate-spawn-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Recreate Spawn Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			mg.Status.ID = "9999"
+			mg.Status.Ready = true
+			Expect(k8sClient.Status().Update(ctx, mg)).To(Succeed())
+
+			beforeCreates := serverState.MonitorGroupCreateCount()
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverState.MonitorGroupCreateCount()).To(Equal(beforeCreates+1), "no matching group means recreate must POST exactly once")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).NotTo(Equal("9999"))
+			Expect(mg.Status.Ready).To(BeTrue())
+
+			close(recorder.Events)
+			sawRecreated := false
+			for event := range recorder.Events {
+				if strings.Contains(event, "Recreated") {
+					sawRecreated = true
+				}
+			}
+			Expect(sawRecreated).To(BeTrue(), "expected a Recreated event after spawn")
+		})
+
+		It("should surface AdoptionLookupFailed when the recreate-path list call fails", func() {
+			DeferCleanup(serverState.Reset)
+			serverState.SetMutateMonitorGroupHTTPStatus(http.StatusNotFound)
+			serverState.SetMonitorGroupsListHTTPStatus(http.StatusInternalServerError)
+
+			mg := CreateMonitorGroup(ctx, "test-recreate-list-fail-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Recreate List Fail Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			mg.Status.ID = "9999"
+			mg.Status.Ready = true
+			Expect(k8sClient.Status().Update(ctx, mg)).To(Succeed())
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).To(HaveOccurred())
+
+			Eventually(recorder.Events, 2*time.Second, 50*time.Millisecond).Should(Receive(ContainSubstring("AdoptionLookupFailed")))
+		})
+
 		It("should warn and adopt the lowest ID when multiple backend groups share the FriendlyName", func() {
 			DeferCleanup(serverState.Reset)
 			serverState.SetMonitorGroups([]map[string]any{

--- a/internal/controller/monitorgroup_controller_test.go
+++ b/internal/controller/monitorgroup_controller_test.go
@@ -515,6 +515,49 @@ var _ = Describe("MonitorGroup Controller", func() {
 			Expect(sawRecreated).To(BeTrue(), "expected a Recreated event after spawn")
 		})
 
+		It("should warn about name collisions when the recreate path adopts across duplicates", func() {
+			DeferCleanup(serverState.Reset)
+			serverState.SetMonitorGroups([]map[string]any{
+				{"id": 7003, "name": "Recreate Collision Group"},
+				{"id": 7001, "name": "Recreate Collision Group"},
+				{"id": 7005, "name": "Recreate Collision Group"},
+			})
+			serverState.SetMutateMonitorGroupHTTPStatus(http.StatusNotFound)
+
+			mg := CreateMonitorGroup(ctx, "test-recreate-collision-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Recreate Collision Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			mg.Status.ID = "9999"
+			mg.Status.Ready = true
+			Expect(k8sClient.Status().Update(ctx, mg)).To(Succeed())
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).To(Equal("7001"), "lowest-ID match wins on the recreate path too")
+
+			close(recorder.Events)
+			sawCollision := false
+			for event := range recorder.Events {
+				if strings.Contains(event, "AdoptionNameCollision") {
+					sawCollision = true
+				}
+			}
+			Expect(sawCollision).To(BeTrue(), "expected an AdoptionNameCollision warning on the recreate path")
+		})
+
 		It("should surface AdoptionLookupFailed when the recreate-path list call fails", func() {
 			DeferCleanup(serverState.Reset)
 			serverState.SetMutateMonitorGroupHTTPStatus(http.StatusNotFound)

--- a/internal/controller/monitorgroup_controller_test.go
+++ b/internal/controller/monitorgroup_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -283,6 +284,47 @@ var _ = Describe("MonitorGroup Controller", func() {
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
 			Expect(mg.Status.ID).To(Equal(createdID))
+		})
+
+		It("should adopt an existing backend group with matching FriendlyName instead of creating a duplicate", func() {
+			// Simulates a previous reconcile that successfully created the backend group
+			// but lost the Status.ID write (non-conflict failure, pod restart, etc.). The
+			// CR sees Status.ID == "" but a backend group with the same FriendlyName
+			// already exists and must be adopted rather than recreated.
+			//
+			// The fake UR backend's GET /monitor-groups fixture lists a group named
+			// "Test Monitor Group" with ID 12345. Using that FriendlyName here makes the
+			// list-and-adopt path observable.
+			mg := CreateMonitorGroup(ctx, "test-adopt-existing-mg", account.Name, uptimerobotv1.MonitorGroupSpec{
+				FriendlyName: "Test Monitor Group",
+			})
+			defer CleanupMonitorGroup(ctx, mg)
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &MonitorGroupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: mg.Name, Namespace: mg.Namespace}, mg)).To(Succeed())
+			Expect(mg.Status.ID).To(Equal("12345"))
+
+			close(recorder.Events)
+			sawAdopted := false
+			for event := range recorder.Events {
+				Expect(event).NotTo(ContainSubstring("Created"))
+				if strings.Contains(event, "Adopted") {
+					sawAdopted = true
+				}
+			}
+			Expect(sawAdopted).To(BeTrue(), "expected an Adopted event recording the adopted backend group ID")
 		})
 
 		It("should surface non-conflict status update errors", func() {

--- a/internal/uptimerobot/client.go
+++ b/internal/uptimerobot/client.go
@@ -1339,14 +1339,27 @@ func (c Client) PurgeGroupFromBackend(ctx context.Context, groupIDString string)
 	return err
 }
 
-// EnumerateGroupsFromBackend fetches all collections via GET
+// EnumerateGroupsFromBackend fetches all collections, following NextLink pagination
+// so callers adopting an existing group by name aren't blind to matches on later pages.
 func (c Client) EnumerateGroupsFromBackend(ctx context.Context) ([]GroupWireFormat, error) {
-	var responsePayload GroupListWireFormat
-	transmitErr := c.doJSON(ctx, http.MethodGet, "monitor-groups", nil, &responsePayload)
-	if transmitErr != nil {
-		return nil, transmitErr
+	var all []GroupWireFormat
+	var resp GroupListWireFormat
+	if err := c.doJSON(ctx, http.MethodGet, "monitor-groups", nil, &resp); err != nil {
+		return nil, err
 	}
-	return responsePayload.Groups, nil
+	all = append(all, resp.Groups...)
+	for resp.NextLink != nil && *resp.NextLink != "" {
+		nextURL := *resp.NextLink
+		if !strings.HasPrefix(nextURL, "http") {
+			nextURL = strings.TrimSuffix(c.url, "/") + "/" + strings.TrimPrefix(nextURL, "/")
+		}
+		resp = GroupListWireFormat{}
+		if err := c.doGetJSON(ctx, nextURL, &resp); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Groups...)
+	}
+	return all, nil
 }
 
 // PauseMonitor pauses a monitor by ID using the v3 API.

--- a/internal/uptimerobot/client_groups_pagination_test.go
+++ b/internal/uptimerobot/client_groups_pagination_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uptimerobot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEnumerateGroupsFromBackend_FollowsNextLink(t *testing.T) {
+	t.Parallel()
+
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/monitor-groups" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		switch r.URL.Query().Get("page") {
+		case "":
+			next := baseURL + "/monitor-groups?page=2"
+			_, _ = w.Write([]byte(`{
+				"nextLink": "` + next + `",
+				"data": [
+					{"id": 1, "name": "Page One"}
+				]
+			}`))
+		case "2":
+			next := baseURL + "/monitor-groups?page=3"
+			_, _ = w.Write([]byte(`{
+				"nextLink": "` + next + `",
+				"data": [
+					{"id": 2, "name": "Page Two"}
+				]
+			}`))
+		case "3":
+			_, _ = w.Write([]byte(`{
+				"nextLink": null,
+				"data": [
+					{"id": 3, "name": "Page Three"}
+				]
+			}`))
+		default:
+			t.Fatalf("unexpected page: %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	client := Client{url: srv.URL, apiKey: "test-key"}
+	groups, err := client.EnumerateGroupsFromBackend(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateGroupsFromBackend returned error: %v", err)
+	}
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups across paginated responses, got %d", len(groups))
+	}
+	if groups[0].ID != 1 || groups[1].ID != 2 || groups[2].ID != 3 {
+		t.Fatalf("unexpected pagination order: %+v", groups)
+	}
+}
+
+func TestEnumerateGroupsFromBackend_RelativeNextLink(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page") {
+		case "":
+			_, _ = w.Write([]byte(`{
+				"nextLink": "/monitor-groups?page=2",
+				"data": [{"id": 10, "name": "Relative One"}]
+			}`))
+		case "2":
+			_, _ = w.Write([]byte(`{
+				"nextLink": null,
+				"data": [{"id": 20, "name": "Relative Two"}]
+			}`))
+		default:
+			t.Fatalf("unexpected page: %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer srv.Close()
+
+	client := Client{url: srv.URL, apiKey: "test-key"}
+	groups, err := client.EnumerateGroupsFromBackend(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateGroupsFromBackend returned error: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups via relative nextLink, got %d", len(groups))
+	}
+}

--- a/internal/uptimerobot/uptimerobottest/server.go
+++ b/internal/uptimerobot/uptimerobottest/server.go
@@ -45,6 +45,9 @@ type ServerState struct {
 	monitorGroupCreateCount    int
 	monitorGroupListPageSize   int // 0 = single page
 	forceMonitorGroupsListHTTP int
+	// forceMutateGroupHTTPStatus forces PATCH /monitor-groups/{id} to return the
+	// configured status code; used by tests to drive the IsNotFound recreate path.
+	forceMutateGroupHTTPStatus int
 	// Force specific HTTP status codes for certain endpoints (0 = normal behavior).
 	forceUserMeHTTPStatus        int
 	forceAlertContactsHTTPStatus int
@@ -138,6 +141,7 @@ func (s *ServerState) Reset() {
 	s.monitorGroupCreateCount = 0
 	s.monitorGroupListPageSize = 0
 	s.forceMonitorGroupsListHTTP = 0
+	s.forceMutateGroupHTTPStatus = 0
 	s.forceUserMeHTTPStatus = 0
 	s.forceAlertContactsHTTPStatus = 0
 	s.forceIntegrationsHTTPStatus = 0
@@ -176,6 +180,15 @@ func (s *ServerState) SetMonitorGroupsListHTTPStatus(code int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.forceMonitorGroupsListHTTP = code
+}
+
+// SetMutateMonitorGroupHTTPStatus forces PATCH /monitor-groups/{id} to return
+// the given status code. Useful for driving the IsNotFound recreate path. Set
+// to 0 to restore normal behaviour.
+func (s *ServerState) SetMutateMonitorGroupHTTPStatus(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forceMutateGroupHTTPStatus = code
 }
 
 // SetMonitorGroupListPageSize controls pagination for GET /monitor-groups.
@@ -474,7 +487,9 @@ func NewServerWithState(state *ServerState) *httptest.Server {
 	})
 
 	// PATCH /monitor-groups/{id} - Update monitor group
-	mux.HandleFunc("PATCH /monitor-groups/", handleUpdateMonitorGroup)
+	mux.HandleFunc("PATCH /monitor-groups/", func(w http.ResponseWriter, _ *http.Request) {
+		handleUpdateMonitorGroup(w, state)
+	})
 
 	// DELETE /monitor-groups/{id} - Delete monitor group
 	mux.HandleFunc("DELETE /monitor-groups/", handleDeleteMonitorGroup)
@@ -737,7 +752,16 @@ func handleCreateMonitorGroup(w http.ResponseWriter, r *http.Request, state *Ser
 	_ = json.NewEncoder(w).Encode(entry)
 }
 
-func handleUpdateMonitorGroup(w http.ResponseWriter, r *http.Request) {
+func handleUpdateMonitorGroup(w http.ResponseWriter, state *ServerState) {
+	state.mu.RLock()
+	code := state.forceMutateGroupHTTPStatus
+	state.mu.RUnlock()
+	if code != 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "forced error for testing"})
+		return
+	}
 	serveJSONFile(w, "monitor_group_update.json", 0)
 }
 

--- a/internal/uptimerobot/uptimerobottest/server.go
+++ b/internal/uptimerobot/uptimerobottest/server.go
@@ -36,9 +36,10 @@ type ServerState struct {
 	createMonitorID int
 	integrations    map[int]map[string]any
 	nextIntegration int
-	// Stateful monitor-group backing so adoption-by-name and POST-then-GET tests are
-	// observable. Seeded with the legacy fixture (id=12345 "Test Monitor Group") for
-	// backward compatibility with existing fixture-driven tests.
+	// Stateful monitor-group backing for adoption-by-name lookups and the POST
+	// create-counter. Affects the list endpoint only — GET /monitor-groups/{id}
+	// still serves the legacy single-group fixture. Seeded with the legacy list
+	// fixture (id=12345 "Test Monitor Group") for backward compatibility.
 	monitorGroups              []map[string]any
 	nextMonitorGroupID         int
 	monitorGroupCreateCount    int

--- a/internal/uptimerobot/uptimerobottest/server.go
+++ b/internal/uptimerobot/uptimerobottest/server.go
@@ -36,6 +36,14 @@ type ServerState struct {
 	createMonitorID int
 	integrations    map[int]map[string]any
 	nextIntegration int
+	// Stateful monitor-group backing so adoption-by-name and POST-then-GET tests are
+	// observable. Seeded with the legacy fixture (id=12345 "Test Monitor Group") for
+	// backward compatibility with existing fixture-driven tests.
+	monitorGroups              []map[string]any
+	nextMonitorGroupID         int
+	monitorGroupCreateCount    int
+	monitorGroupListPageSize   int // 0 = single page
+	forceMonitorGroupsListHTTP int
 	// Force specific HTTP status codes for certain endpoints (0 = normal behavior).
 	forceUserMeHTTPStatus        int
 	forceAlertContactsHTTPStatus int
@@ -67,14 +75,29 @@ func defaultIntegrations() (map[int]map[string]any, int) {
 	}, 102
 }
 
+func defaultMonitorGroups() ([]map[string]any, int) {
+	return []map[string]any{
+		{
+			"id":         12345,
+			"name":       "Test Monitor Group",
+			"createdAt":  "2026-02-06T20:00:00Z",
+			"updatedAt":  "2026-02-06T20:00:00Z",
+			"monitorIds": []int{},
+		},
+	}, 12346
+}
+
 // NewServerState creates a new server state tracker.
 func NewServerState() *ServerState {
 	integrations, next := defaultIntegrations()
+	groups, nextGroup := defaultMonitorGroups()
 	return &ServerState{
-		deletedMonitors: make(map[string]bool),
-		createMonitorID: 777810874,
-		integrations:    integrations,
-		nextIntegration: next,
+		deletedMonitors:    make(map[string]bool),
+		createMonitorID:    777810874,
+		integrations:       integrations,
+		nextIntegration:    next,
+		monitorGroups:      groups,
+		nextMonitorGroupID: nextGroup,
 	}
 }
 
@@ -104,16 +127,83 @@ func (s *ServerState) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	integrations, next := defaultIntegrations()
+	groups, nextGroup := defaultMonitorGroups()
 	s.deletedMonitors = make(map[string]bool)
 	s.createMonitorID = 777810874
 	s.integrations = integrations
 	s.nextIntegration = next
+	s.monitorGroups = groups
+	s.nextMonitorGroupID = nextGroup
+	s.monitorGroupCreateCount = 0
+	s.monitorGroupListPageSize = 0
+	s.forceMonitorGroupsListHTTP = 0
 	s.forceUserMeHTTPStatus = 0
 	s.forceAlertContactsHTTPStatus = 0
 	s.forceIntegrationsHTTPStatus = 0
 	s.forceGlobalHTTPStatus = 0
 	s.intermittentFailStatus = 0
 	s.intermittentFailCount = 0
+}
+
+// SetMonitorGroups replaces the in-memory monitor-group list. Used by tests that
+// want to seed a specific population (e.g. multi-page or name-collision scenarios).
+// Each entry should contain at least "id" and "name"; other fields are passed
+// through verbatim.
+func (s *ServerState) SetMonitorGroups(groups []map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.monitorGroups = make([]map[string]any, len(groups))
+	maxID := 0
+	for i, g := range groups {
+		entry := make(map[string]any, len(g))
+		for k, v := range g {
+			entry[k] = v
+		}
+		s.monitorGroups[i] = entry
+		if id, ok := toInt(entry["id"]); ok && id >= maxID {
+			maxID = id + 1
+		}
+	}
+	if maxID > s.nextMonitorGroupID {
+		s.nextMonitorGroupID = maxID
+	}
+}
+
+// SetMonitorGroupsListHTTPStatus forces GET /monitor-groups to return the given
+// status code. Set to 0 to restore normal behaviour.
+func (s *ServerState) SetMonitorGroupsListHTTPStatus(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forceMonitorGroupsListHTTP = code
+}
+
+// SetMonitorGroupListPageSize controls pagination for GET /monitor-groups.
+// 0 (default) returns the full list on a single page.
+func (s *ServerState) SetMonitorGroupListPageSize(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.monitorGroupListPageSize = n
+}
+
+// MonitorGroupCreateCount returns how many POST /monitor-groups requests have
+// been served since the last Reset. Used by tests to assert that a duplicate
+// create did or did not happen.
+func (s *ServerState) MonitorGroupCreateCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.monitorGroupCreateCount
+}
+
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
 }
 
 // SetGlobalHTTPStatus forces every endpoint to return the given HTTP status code.
@@ -370,11 +460,17 @@ func NewServerWithState(state *ServerState) *httptest.Server {
 	mux.HandleFunc("DELETE /maintenance-windows/", handleDeleteMaintenanceWindow)
 
 	// GET /monitor-groups - List monitor groups
-	mux.HandleFunc("GET /monitor-groups", handleGetMonitorGroups)
-	mux.HandleFunc("GET /monitor-groups/", handleGetMonitorGroups)
+	mux.HandleFunc("GET /monitor-groups", func(w http.ResponseWriter, r *http.Request) {
+		handleGetMonitorGroups(w, r, state)
+	})
+	mux.HandleFunc("GET /monitor-groups/", func(w http.ResponseWriter, r *http.Request) {
+		handleGetMonitorGroups(w, r, state)
+	})
 
 	// POST /monitor-groups - Create monitor group
-	mux.HandleFunc("POST /monitor-groups", handleCreateMonitorGroup)
+	mux.HandleFunc("POST /monitor-groups", func(w http.ResponseWriter, r *http.Request) {
+		handleCreateMonitorGroup(w, r, state)
+	})
 
 	// PATCH /monitor-groups/{id} - Update monitor group
 	mux.HandleFunc("PATCH /monitor-groups/", handleUpdateMonitorGroup)
@@ -535,21 +631,109 @@ func handleDeleteMaintenanceWindow(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func handleGetMonitorGroups(w http.ResponseWriter, r *http.Request) {
+func handleGetMonitorGroups(w http.ResponseWriter, r *http.Request, state *ServerState) {
 	// Check for specific monitor group ID in path
 	path := strings.TrimPrefix(r.URL.Path, "/monitor-groups/")
 	if path != "" && path != r.URL.Path {
-		// Single monitor group request
+		// Single monitor group request — keep returning the legacy fixture to avoid
+		// rewriting unrelated tests that exercise FetchGroupFromBackend.
 		serveJSONFile(w, "monitor_group.json", 0)
 		return
 	}
 
-	// List monitor groups
-	serveJSONFile(w, "monitor_groups.json", 0)
+	state.mu.Lock()
+	if state.forceMonitorGroupsListHTTP != 0 {
+		code := state.forceMonitorGroupsListHTTP
+		state.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "forced error for testing"})
+		return
+	}
+	pageSize := state.monitorGroupListPageSize
+	groupsCopy := make([]map[string]any, len(state.monitorGroups))
+	for i, g := range state.monitorGroups {
+		entry := make(map[string]any, len(g))
+		for k, v := range g {
+			entry[k] = v
+		}
+		groupsCopy[i] = entry
+	}
+	state.mu.Unlock()
+
+	page := 1
+	if p := r.URL.Query().Get("page"); p != "" {
+		if parsed, err := strconv.Atoi(p); err == nil && parsed > 0 {
+			page = parsed
+		}
+	}
+
+	var pageItems []map[string]any
+	var nextLink any
+	if pageSize <= 0 || pageSize >= len(groupsCopy) {
+		pageItems = groupsCopy
+		nextLink = nil
+	} else {
+		start := (page - 1) * pageSize
+		if start >= len(groupsCopy) {
+			pageItems = []map[string]any{}
+		} else {
+			end := start + pageSize
+			if end > len(groupsCopy) {
+				end = len(groupsCopy)
+			}
+			pageItems = groupsCopy[start:end]
+		}
+		if (page * pageSize) < len(groupsCopy) {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			nextLink = fmt.Sprintf("%s://%s/monitor-groups?page=%d", scheme, r.Host, page+1)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data":     pageItems,
+		"nextLink": nextLink,
+	})
 }
 
-func handleCreateMonitorGroup(w http.ResponseWriter, r *http.Request) {
-	serveJSONFile(w, "monitor_group_create.json", http.StatusCreated)
+func handleCreateMonitorGroup(w http.ResponseWriter, r *http.Request, state *ServerState) {
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid json"})
+		return
+	}
+	name, _ := body["name"].(string)
+
+	state.mu.Lock()
+	id := state.nextMonitorGroupID
+	state.nextMonitorGroupID++
+	state.monitorGroupCreateCount++
+	monitorIDs := []int{}
+	if raw, ok := body["monitorIds"].([]any); ok {
+		for _, v := range raw {
+			if n, ok := toInt(v); ok {
+				monitorIDs = append(monitorIDs, n)
+			}
+		}
+	}
+	entry := map[string]any{
+		"id":         id,
+		"name":       name,
+		"createdAt":  "2026-02-06T20:00:00Z",
+		"updatedAt":  "2026-02-06T20:00:00Z",
+		"monitorIds": monitorIDs,
+	}
+	state.monitorGroups = append(state.monitorGroups, entry)
+	state.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(entry)
 }
 
 func handleUpdateMonitorGroup(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
PR #181 only retried Status().Update on conflict. Any non-conflict status-write failure (API-server transient error, pod terminated mid- reconcile, network blip) between SpawnGroupInBackend and the persisted Status.ID still left an orphaned backend group and an empty Status.ID, so the next reconcile created a second group.

Make creation idempotent by listing backend groups and adopting one whose Name matches spec.FriendlyName before posting a new group, with deterministic lowest-ID selection so clusters that already accumulated duplicates from this bug converge on the oldest. Move the "Created" event emission to after the successful Status().Update so a lost status write no longer surfaces a misleading event for a group the next reconcile will adopt rather than recreate.

Add a unit test for findAdoptableGroup covering empty name, no match, single match, multiple matches (lowest-ID wins) and empty list, plus a controller integration test that drives the create branch with a FriendlyName matching the fake UR list fixture and asserts adoption rather than creation.

Closes #201