### PR TITLE
test(uptimerobot): pin responseTimeThreshold into monitor requests

### DIFF
--- a/internal/uptimerobot/client_test.go
+++ b/internal/uptimerobot/client_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package uptimerobot
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -275,4 +277,64 @@ func TestBuildUpdateMonitorRequest_PortOmitsURL(t *testing.T) {
 	if wantTimeout := int(timeout.Seconds()); req.Timeout != wantTimeout {
 		t.Errorf("expected Timeout %d for port updates, got %d", wantTimeout, req.Timeout)
 	}
+}
+
+// TestMonitorRequestsCarryResponseTimeThreshold pins the field that the
+// "HTTPS Full" e2e spec reports as lost: it sets responseTimeThreshold=5000 and
+// the UptimeRobot API returns 0. This asserts the operator's side of that
+// exchange -- the value reaches both request structs and survives JSON
+// marshalling under the name the API spec uses (api-spec/monitor-post.json
+// documents "responseTimeThreshold", a number in 0..60000).
+func TestMonitorRequestsCarryResponseTimeThreshold(t *testing.T) {
+	client := NewClient("test-api-key")
+	threshold := 5000
+	interval := metav1.Duration{Duration: 5 * time.Minute}
+	timeout := metav1.Duration{Duration: 30 * time.Second}
+	gracePeriod := metav1.Duration{Duration: time.Minute}
+
+	monitor := uptimerobotv1.MonitorValues{
+		Name:                  "E2E HTTPS Full",
+		Type:                  urtypes.TypeHTTPS,
+		URL:                   "https://httpbin.org/get",
+		Interval:              &interval,
+		Timeout:               &timeout,
+		GracePeriod:           &gracePeriod,
+		ResponseTimeThreshold: &threshold,
+	}
+
+	t.Run("create request", func(t *testing.T) {
+		req := client.buildCreateMonitorRequest(monitor, uptimerobotv1.MonitorContacts{})
+		if req.ResponseTimeThreshold == nil {
+			t.Fatal("expected ResponseTimeThreshold to be set on create")
+		}
+		if *req.ResponseTimeThreshold != threshold {
+			t.Errorf("expected ResponseTimeThreshold %d on create, got %d", threshold, *req.ResponseTimeThreshold)
+		}
+
+		body, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("failed to marshal create request: %v", err)
+		}
+		if !strings.Contains(string(body), `"responseTimeThreshold":5000`) {
+			t.Errorf("create request JSON missing responseTimeThreshold: %s", body)
+		}
+	})
+
+	t.Run("update request", func(t *testing.T) {
+		req := client.buildUpdateMonitorRequest(monitor, nil)
+		if req.ResponseTimeThreshold == nil {
+			t.Fatal("expected ResponseTimeThreshold to be set on update")
+		}
+		if *req.ResponseTimeThreshold != threshold {
+			t.Errorf("expected ResponseTimeThreshold %d on update, got %d", threshold, *req.ResponseTimeThreshold)
+		}
+
+		body, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("failed to marshal update request: %v", err)
+		}
+		if !strings.Contains(string(body), `"responseTimeThreshold":5000`) {
+			t.Errorf("update request JSON missing responseTimeThreshold: %s", body)
+		}
+	})
 }


### PR DESCRIPTION
## Why

The `HTTPS Full` e2e spec fails **deterministically** (reproduced identically across two `/run-e2e` runs):

```
field validation: 1 field error(s): [responseTimeThreshold: got 0 want 5000]
```

It sets `responseTimeThreshold: 5000` and the UptimeRobot API reports back `0`.

This PR does not change behaviour. It pins the operator's half of that exchange so the boundary isn't guessed at again.

## What the test asserts

That the value reaches **both** the create and update request structs, and survives JSON marshalling as `"responseTimeThreshold":5000` — the name and shape documented in `api-spec/monitor-post.json` (number, `0..60000`).

It passes. Combined with the rest of the investigation, that rules the operator out:

| Checked | Result |
|---|---|
| Field in generated CRD schema | present, `minimum: 0`, `maximum: 60000` — apiserver is not pruning it |
| e2e manifest nesting | correct, under `spec.monitor` |
| `client.go:448` / `:589` | set on create and update whenever non-nil, no monitor-type gating |
| Request JSON name/shape | matches `api-spec/monitor-post.json` exactly |

So a spec-correct request goes out on both create and update — the spec runs `syncInterval: 1m` against a 180s poll, so at least one update cycle also PATCHes it — and the API still returns `0`.

## Where that leaves it

The discrepancy is on the UptimeRobot side: either an API limitation, or `responseTimeThreshold` is plan-gated and the account behind the e2e key doesn't have it.

**The e2e assertion is deliberately left as-is.** If the field turns out to be unavailable on that account, the expectation should be dropped with that reason recorded. If the API regressed, the assertion is doing its job and shouldn't be weakened to make the suite green.

Note this spec sits in an `Ordered` container, so it currently skips everything after it — resolving it will unlock more than the 27 of 79 specs that run today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)